### PR TITLE
Use daysToDelete parameter for IIS logs

### DIFF
--- a/scripts/Win_Start_Cleanup.ps1
+++ b/scripts/Win_Start_Cleanup.ps1
@@ -133,7 +133,7 @@ param(
     ## Cleans IIS Logs older then $DaysToDelete
     if (Test-Path C:\inetpub\logs\LogFiles\) {
         Get-ChildItem "C:\inetpub\logs\LogFiles\*" -Recurse -Force -ErrorAction SilentlyContinue |
-            Where-Object { ($_.CreationTime -lt $(Get-Date).AddDays(-60)) } | Remove-Item -Force -Verbose -Recurse -ErrorAction SilentlyContinue
+            Where-Object { ($_.CreationTime -lt $(Get-Date).AddDays(-$DaysToDelete)) } | Remove-Item -Force -Verbose -Recurse -ErrorAction SilentlyContinue
         Write-Host "All IIS Logfiles over $DaysToDelete days old have been removed Successfully!                  " -NoNewline -ForegroundColor Green
         Write-Host "[DONE]" -ForegroundColor Green -BackgroundColor Black
     }


### PR DESCRIPTION
This change is to use the intended $DaysToDelete rather than a hard-coded value of 60 days for deleting IIS Logs