### PR TITLE
When checking if patches are to be installed, don't exit the function after finding a patched machine.

### DIFF
--- a/api/tacticalrmm/winupdate/tasks.py
+++ b/api/tacticalrmm/winupdate/tasks.py
@@ -72,7 +72,7 @@ def check_agent_update_schedule_task() -> None:
                 if last_installed.strftime("%d/%m/%Y") == agent_localtime_now.strftime(
                     "%d/%m/%Y"
                 ):
-                    return
+                    continue
 
             # check if schedule is set to daily/weekly and if now is the time to run
             if (


### PR DESCRIPTION
Currently `check_agent_update_schedule_task()` will return after finding a machine which has already been patched the same day, this prevents any agents later in the list getting updates.

Returning is ok if only 1 patch policy triggers per day, but if client1 patches at 03:00 and client2 patches at 19:00 then client2 won't get all patches if any agents from client1 are online.

Fixes #1270 

