### PR TITLE
break from loop once a valid policy is found. remove old unused list

### DIFF
--- a/api/tacticalrmm/agents/models.py
+++ b/api/tacticalrmm/agents/models.py
@@ -618,17 +618,18 @@ class Agent(BaseAuditModel):
         if not agent_policy:
             agent_policy = WinUpdatePolicy.objects.create(agent=self)
 
+        # Get the list of policies applied to the agent and select the
+        # highest priority one.
         policies = self.get_agent_policies()
 
-        processed_policies: List[int] = []
         for _, policy in policies.items():
             if (
                 policy
                 and policy.active
-                and policy.pk not in processed_policies
                 and policy.winupdatepolicy.exists()
             ):
                 patch_policy = policy.winupdatepolicy.first()
+                break
 
         # if policy still doesn't exist return the agent patch policy
         if not patch_policy:

--- a/api/tacticalrmm/agents/models.py
+++ b/api/tacticalrmm/agents/models.py
@@ -623,11 +623,7 @@ class Agent(BaseAuditModel):
         policies = self.get_agent_policies()
 
         for _, policy in policies.items():
-            if (
-                policy
-                and policy.active
-                and policy.winupdatepolicy.exists()
-            ):
+            if policy and policy.active and policy.winupdatepolicy.exists():
                 patch_policy = policy.winupdatepolicy.first()
                 break
 


### PR DESCRIPTION
`get_patch_policy()` was always going through to the end of the agent policies list instead of breaking from the loop once a valid policy is found. Since `get_agent_policies()` returns the list in order of preference, the least preferred policy was always getting selected.

Also removed the `processed_policies` list which is not used, seems to be left over from when the policy was selected a different way.

Fixes #1293 