### PR TITLE
WIP: Simplified Agent Installer

### DIFF
--- a/api/tacticalrmm/agents/urls.py
+++ b/api/tacticalrmm/agents/urls.py
@@ -42,4 +42,5 @@ urlpatterns = [
     path("update/", views.update_agents),
     path("installer/", views.install_agent),
     path("bulkrecovery/", views.bulk_agent_recovery),
+    path("installer/linux", views.install_agent_linux),
 ]

--- a/api/tacticalrmm/agents/utils.py
+++ b/api/tacticalrmm/agents/utils.py
@@ -33,8 +33,62 @@ def generate_linux_install(
     token: str,
     api: str,
     download_url: str,
+    download_only: bool=False,
 ) -> FileResponse:
 
+    text = Path(settings.LINUX_AGENT_SCRIPT).read_text()
+
+    # replace contents
+    if not download_only:
+        match arch:
+            case "amd64":
+                arch_id = MeshAgentIdent.LINUX64
+            case "386":
+                arch_id = MeshAgentIdent.LINUX32
+            case "arm64":
+                arch_id = MeshAgentIdent.LINUX_ARM_64
+            case "arm":
+                arch_id = MeshAgentIdent.LINUX_ARM_HF
+            case _:
+                arch_id = "not_found"
+
+        core = get_core_settings()
+
+        uri = get_mesh_ws_url()
+        mesh_id = asyncio.run(get_mesh_device_id(uri, core.mesh_device_group))
+        mesh_dl = (
+            f"{core.mesh_site}/meshagents?id={mesh_id}&installflags=2&meshinstall={arch_id}"
+        )
+
+        replace = {
+            "agentDLChange": download_url,
+            "meshDLChange": mesh_dl,
+            "clientIDChange": client,
+            "siteIDChange": site,
+            "agentTypeChange": agent_type,
+            "tokenChange": token,
+            "apiURLChange": api,
+        }
+
+        for i, j in replace.items():
+            text = text.replace(i, j)
+
+    with tempfile.NamedTemporaryFile() as fp:
+        with open(fp.name, "w") as f:
+            f.write(text)
+            f.write("\n")
+
+        return FileResponse(
+            open(fp.name, "rb"), as_attachment=True, filename="linux_agent_install.sh"
+        )
+
+
+def generate_linux_install_command(
+    install_flags: list,
+    arch: str,
+    curl_url: str,
+    download_url: str,
+):
     match arch:
         case "amd64":
             arch_id = MeshAgentIdent.LINUX64
@@ -55,26 +109,7 @@ def generate_linux_install(
         f"{core.mesh_site}/meshagents?id={mesh_id}&installflags=2&meshinstall={arch_id}"
     )
 
-    text = Path(settings.LINUX_AGENT_SCRIPT).read_text()
-
-    replace = {
-        "agentDLChange": download_url,
-        "meshDLChange": mesh_dl,
-        "clientIDChange": client,
-        "siteIDChange": site,
-        "agentTypeChange": agent_type,
-        "tokenChange": token,
-        "apiURLChange": api,
-    }
-
-    for i, j in replace.items():
-        text = text.replace(i, j)
-
-    with tempfile.NamedTemporaryFile() as fp:
-        with open(fp.name, "w") as f:
-            f.write(text)
-            f.write("\n")
-
-        return FileResponse(
-            open(fp.name, "rb"), as_attachment=True, filename="linux_agent_install.sh"
-        )
+    install_flags.extend(["--meshdl", f"'{mesh_dl}'", "--agentdl", f"'{download_url}'"])
+    return (
+        f"curl -FL '{curl_url}' | sudo bash -s -- " + " ".join(str(i) for i in install_flags)
+    )

--- a/api/tacticalrmm/agents/views.py
+++ b/api/tacticalrmm/agents/views.py
@@ -549,7 +549,7 @@ def install_agent(request):
 
     codesign_token, is_valid = token_is_valid()
 
-    if request.data["installMethod"] in {"bash", "mac"} and is_valid:
+    if request.data["installMethod"] in {"bash", "mac"} and not is_valid:
         return notify_error(
             "Missing code signing token, or token is no longer valid. Please read the docs for more info."
         )

--- a/api/tacticalrmm/agents/views.py
+++ b/api/tacticalrmm/agents/views.py
@@ -11,12 +11,14 @@ from django.db.models import Count, Exists, OuterRef, Prefetch, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone as djangotime
+from django.urls import reverse
+from agents.utils import generate_linux_install, generate_linux_install_command
 from meshctrl.utils import get_login_token
 from packaging import version as pyver
 from rest_framework import serializers
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -547,7 +549,7 @@ def install_agent(request):
 
     codesign_token, is_valid = token_is_valid()
 
-    if request.data["installMethod"] in {"bash", "mac"} and not is_valid:
+    if request.data["installMethod"] in {"bash", "mac"} and is_valid:
         return notify_error(
             "Missing code signing token, or token is no longer valid. Please read the docs for more info."
         )
@@ -609,7 +611,7 @@ def install_agent(request):
             download_url=download_url,
         )
 
-    elif request.data["installMethod"] in {"manual", "mac"}:
+    elif request.data["installMethod"] in {"manual", "mac", "bash-manual"}:
         resp = {}
         if request.data["installMethod"] == "manual":
             cmd = [
@@ -633,6 +635,12 @@ def install_agent(request):
                 cmd.append("--power")
 
             resp["cmd"] = " ".join(str(i) for i in cmd)
+        elif request.data["installMethod"] == "bash-manual":
+            curl_url = request.build_absolute_uri(reverse(install_agent_linux))
+            cmd = install_flags.copy()
+            cmd.remove('-m')
+            cmd.remove('install')
+            resp["cmd"] = generate_linux_install_command(cmd, goarch, curl_url, download_url)
         else:
             install_flags.insert(0, f"sudo ./{inno}")
             cmd = install_flags.copy()
@@ -687,6 +695,19 @@ def install_agent(request):
             response["X-Accel-Redirect"] = f"/private/exe/{file_name}"
             return response
 
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def install_agent_linux(request):
+    return generate_linux_install(
+        download_only=True,
+        client="",
+        site="",
+        agent_type="",
+        arch="",
+        token="",
+        api="",
+        download_url="",
+    )
 
 @api_view(["POST"])
 @permission_classes([IsAuthenticated, RecoverAgentPerms])

--- a/api/tacticalrmm/core/agent_linux.sh
+++ b/api/tacticalrmm/core/agent_linux.sh
@@ -33,6 +33,22 @@ meshSystemBin="${meshDir}/meshagent"
 meshSvcName='meshagent.service'
 meshSysD="/lib/systemd/system/${meshSvcName}"
 
+# Simple Bash Argument Handler
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -t|--token|--auth) token="$2"; shift ;;
+        -c|--client-id) clientID="$2"; shift ;;
+        -s|--site-id) siteID="$2"; shift ;;
+        -a|--agent-type) agentType="$2"; shift;;
+        --proxy) proxy="$2"; shift;;
+        --api) apiURL="$2"; shift;;
+        --agentdl) agentDL="$2"; shift;;
+        --meshdl) meshDL="$2"; shift;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
 deb=(ubuntu debian raspbian kali linuxmint)
 rhe=(fedora rocky centos rhel amzn arch opensuse)
 


### PR DESCRIPTION
The goal of this PR is to update the current agent installer (primarily for linux) to provide a simple command to copy/paste and then run on a remote server without having to copy an installer script around. If this is something of use to the devs, I would like to continue the work here to allow the same functionality on Windows. The macOS install command is pretty close to this already.

Here are the UI changes (provided in a separate PR on the amidaware/tacticalrmm-web repo)

![image](https://user-images.githubusercontent.com/33401067/201568441-fb520363-f254-44bf-bf78-0dc4a6d83d8f.png)

![image](https://user-images.githubusercontent.com/33401067/201568507-9eaa9665-2416-48f5-bc68-c54e2a503afe.png)
