### PR TITLE
WIP: add initial support for prometheus metrics.

### DIFF
--- a/api/tacticalrmm/core/decorators.py
+++ b/api/tacticalrmm/core/decorators.py
@@ -6,23 +6,35 @@ from django.http import HttpResponse
 
 def monitoring_view(function):
     def wrap(request, *args, **kwargs):
-        if request.method != "POST":
+        if request.method == "POST":
+            try:
+                data = json.loads(request.body)
+            except:
+                return HttpResponse("Invalid json\n", status=400)
+
+            if "auth" not in data.keys():
+                return HttpResponse("Invalid payload\n", status=400)
+
+            token = getattr(settings, "MON_TOKEN", "")
+            if not token:
+                return HttpResponse("Missing token\n", status=401)
+
+            if data.get("auth") != token:
+                return HttpResponse("Not authenticated\n", status=401)
+
+        elif request.method == "GET":
+            if "Authorization" not in request.headers:
+                return HttpResponse("Missing 'Authorization' header\n", status=400)
+
+            token = getattr(settings, "MON_TOKEN", "")
+            if not token:
+                return HttpResponse("Missing token\n", status=401)
+
+            if request.headers["Authorization"] != "Bearer " + token:
+                return HttpResponse("Not authenticated\n", status=401)
+
+        else:
             return HttpResponse("Invalid request type\n", status=400)
-
-        try:
-            data = json.loads(request.body)
-        except:
-            return HttpResponse("Invalid json\n", status=400)
-
-        if "auth" not in data.keys():
-            return HttpResponse("Invalid payload\n", status=400)
-
-        token = getattr(settings, "MON_TOKEN", "")
-        if not token:
-            return HttpResponse("Missing token\n", status=401)
-
-        if data.get("auth") != token:
-            return HttpResponse("Not authenticated\n", status=401)
 
         return function(request, *args, **kwargs)
 


### PR DESCRIPTION
Could someone look over this and let me know if this okay for adding initial support for Prometheus metrics?
1. At the moment this includes a minimal amount of metrics as examples. I may tweak the metric names a bit after I review the Prometheus metrics best practices document again.
2. The endpoint `/metrics` is used as that is traditional for Prometheus environments. I can change it back to `/core/metrics` if required.
3. Do I need to add any tests for this?
4. I am not sure if `@csrf_exempt` is actually needed or wanted here; the monitoring endpoint made it seem so, to me.
5. Is the for loop at the end okay or should I do this differently? (ie direct calls each time, or should it be a comprehension?)
6. Is there are reason not to expose some of the version info? The reason it is there now is to track updates in my metrics environment. I think this may be useful if I find clients dropping off after an upgrade for example.
7. Is there any other feedback?

---
Use instructions:
1. Setup `MON_TOKEN` as in [Tips and Tricks](https://docs.tacticalrmm.com/tipsntricks/#monitor-your-trmm-instance-via-the-built-in-monitoring-endpoint).
2. Test with curl command `curl -s -H "Authorization: Bearer $MON_TOKEN" https://api.trmm.example.com/metrics`
3. Setup Prometheus job with:
```
- job_name: trmm
  scrape_interval: 60s
  #metrics_path: /core/status/
  scheme: https
  bearer_token: $MON_TOKEN
  static_configs:
  - targets:
    - api.trmm.example.com
```

edit: updated instructions to share json status endpoint. instructions also in commit message now.