### PR TITLE
Enable hostname filtering for bulk agents deletion

### DIFF
--- a/api/tacticalrmm/agents/management/commands/bulk_delete_agents.py
+++ b/api/tacticalrmm/agents/management/commands/bulk_delete_agents.py
@@ -34,6 +34,11 @@ class Command(BaseCommand):
             help="Delete agents that belong to the specified client",
         )
         parser.add_argument(
+            "--hostname",
+            type=str,
+            help="Delete agents with hostname starting with argument",
+        )
+        parser.add_argument(
             "--delete",
             action="store_true",
             help="This will delete agents",
@@ -44,12 +49,13 @@ class Command(BaseCommand):
         agentver = kwargs["agentver"]
         site = kwargs["site"]
         client = kwargs["client"]
+        hostname = kwargs["hostname"]
         delete = kwargs["delete"]
 
-        if not days and not agentver and not site and not client:
+        if not days and not agentver and not site and not client and not hostname:
             self.stdout.write(
                 self.style.ERROR(
-                    "Must have at least one parameter: days, agentver, site, or client"
+                    "Must have at least one parameter: days, agentver, site, client or hostname"
                 )
             )
             return
@@ -69,6 +75,9 @@ class Command(BaseCommand):
 
         if client:
             agents = [i for i in q if i.client.name == client]
+
+        if hostname:
+            agents = [i for i in q if i.hostname.startswith(hostname)]
 
         if not agents:
             self.stdout.write(self.style.ERROR("No agents matched"))


### PR DESCRIPTION
Hey,
From time to time we need to replace a batch of computers and we need to remove the  old agents in tacticalrmm. As they all start with the same hostname, this commit enables filtering them for deletion by hostname.

On a side note, it would be nice (for me) to use multiple filter at once, days and hostname for instance. I see that there are some optimizations going on and didn't suggest code changes. What I could submit, is to use a `.filter()` on the `QuerySet` for all the arguments except for the `agentver` which would remain unchanged. If this make sense, let me know and I will submit another PR.