### PR TITLE
Replace mongodb with postgres

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,8 +13,6 @@ MESH_HOST=mesh.example.com
 # mesh settings
 MESH_USER=tactical
 MESH_PASS=tactical
-MONGODB_USER=mongouser
-MONGODB_PASSWORD=mongopass
 MESH_PERSISTENT_CONFIG=0
 
 # database settings

--- a/docker/containers/tactical-meshcentral/entrypoint.sh
+++ b/docker/containers/tactical-meshcentral/entrypoint.sh
@@ -4,10 +4,13 @@ set -e
 
 : "${MESH_USER:=meshcentral}"
 : "${MESH_PASS:=meshcentralpass}"
-: "${MONGODB_USER:=mongouser}"
-: "${MONGODB_PASSWORD:=mongopass}"
-: "${MONGODB_HOST:=tactical-mongodb}"
-: "${MONGODB_PORT:=27017}"
+: "${POSTGRES_USER:=pguser}"
+: "${POSTGRES_PASS:=pgpass}"
+: "${POSTGRES_HOST:=trmm-postgres}"
+: "${POSTGRES_PORT:=5432}"
+: "${POSTGRES_DB:=meshcentral}"
+: "${POSTGRES_SSL:=false}"
+: "${NODE_TLS_REJECT_UNAUTHORIZED:=1}"
 : "${NGINX_HOST_IP:=172.20.0.20}"
 : "${NGINX_HOST_PORT:=4443}"
 : "${MESH_COMPRESSION_ENABLED:=true}"
@@ -28,7 +31,16 @@ if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTE
   mesh_config="$(cat << EOF
 {
   "settings": {
-    "mongodb": "${encoded_uri}",
+    "postgres": {
+      "host": "${POSTGRES_HOST}",
+      "user": "${POSTGRES_USER}",
+      "port": ${POSTGRES_PORT},
+      "password": "${POSTGRES_PASS}",
+      "database": "${POSTGRES_DB}",
+      "ssl": {
+        "require": ${POSTGRES_SSL}
+      }
+    },
     "cert": "${MESH_HOST}",
     "tlsOffload": "${NGINX_HOST_IP}",
     "redirPort": 8080,

--- a/docker/containers/tactical/entrypoint.sh
+++ b/docker/containers/tactical/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 : "${TRMM_USER:=tactical}"
 : "${TRMM_PASS:=tactical}"
-: "${POSTGRES_HOST:=tactical-postgres}"
+: "${POSTGRES_HOST:=tactical-db}"
 : "${POSTGRES_PORT:=5432}"
 : "${POSTGRES_USER:=tactical}"
 : "${POSTGRES_PASS:=tactical}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,15 +15,15 @@ networks:
 # docker managed persistent volumes
 volumes:
   tactical_data: null
-  postgres_data: null
-  mongo_data: null
+  tactical_db: null
   mesh_data: null
+  mesh_db: null
   redis_data: null
 
 services:
   # postgres database for api service
-  tactical-postgres:
-    container_name: trmm-postgres
+  tactical-db:
+    container_name: trmm-db
     image: postgres:13-alpine
     restart: always
     environment:
@@ -31,9 +31,25 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASS}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - tactical_db:/var/lib/postgresql/data
     networks:
       - api-db
+
+  # postgres database for meshcentral service
+  tactical-mesh-db:
+    container_name: trmm-mesh-db
+    image: postgres:13-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: meshcentral
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASS}
+    volumes:
+      - mesh_db:/var/lib/postgresql/data
+    networks:
+      - mesh-db
+    ports:
+      - "5555:5432"
 
   # redis container for celery tasks
   tactical-redis:
@@ -63,7 +79,7 @@ services:
       TRMM_USER: ${TRMM_USER}
       TRMM_PASS: ${TRMM_PASS}
     depends_on:
-      - tactical-postgres
+      - tactical-db
       - tactical-meshcentral
       - tactical-redis
     networks:
@@ -73,7 +89,7 @@ services:
     volumes:
       - tactical_data:/opt/tactical
       - mesh_data:/meshcentral-data
-      - mongo_data:/mongo/data/db
+      - mesh_db:/meshcentral-db
       - redis_data:/redis/data
 
   # nats
@@ -104,8 +120,10 @@ services:
       MESH_HOST: ${MESH_HOST}
       MESH_USER: ${MESH_USER}
       MESH_PASS: ${MESH_PASS}
-      MONGODB_USER: ${MONGODB_USER}
-      MONGODB_PASSWORD: ${MONGODB_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASS: ${POSTGRES_PASS}
+      POSTGRES_HOST: tactical-mesh-db
+      POSTGRES_PORT: 5555
       MESH_PERSISTENT_CONFIG: ${MESH_PERSISTENT_CONFIG}
     networks:
       proxy:
@@ -116,22 +134,7 @@ services:
       - tactical_data:/opt/tactical
       - mesh_data:/home/node/app/meshcentral-data
     depends_on:
-      - tactical-mongodb
-
-  # mongodb container for meshcentral
-  tactical-mongodb:
-    container_name: trmm-mongodb
-    image: mongo:4.4
-    user: 1000:1000
-    restart: always
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGODB_USER}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_PASSWORD}
-      MONGO_INITDB_DATABASE: meshcentral
-    networks:
-      - mesh-db
-    volumes:
-      - mongo_data:/data/db
+      - tactical-mesh-db
 
   # container that hosts vue frontend
   tactical-frontend:
@@ -160,7 +163,7 @@ services:
     volumes:
       - tactical_data:/opt/tactical
     depends_on:
-      - tactical-postgres
+      - tactical-db
 
   # container for django websockets connections
   tactical-websockets:
@@ -176,7 +179,7 @@ services:
     volumes:
       - tactical_data:/opt/tactical
     depends_on:
-      - tactical-postgres
+      - tactical-db
       - tactical-backend
 
   # container for tactical reverse proxy
@@ -214,7 +217,7 @@ services:
     volumes:
       - tactical_data:/opt/tactical
     depends_on:
-      - tactical-postgres
+      - tactical-db
       - tactical-redis
 
   # container for celery beat service
@@ -231,5 +234,5 @@ services:
     volumes:
       - tactical_data:/opt/tactical
     depends_on:
-      - tactical-postgres
+      - tactical-db
       - tactical-redis


### PR DESCRIPTION
Hey guys, this one does require some testing.

I did not have time to build all containers locally and test - I was only able to verify basic deployment by running a docker-compose.

Please build and test at your discretion; we may need to script something to create the default 'postgres' database for example if MeshCentral doesn't spin up.

Other than that, all the environment variables in the start script from the Discord chat are there; I am using in prod right now in my k8s and it works with my Postgres DB which is not in the cluster, so slightly different setup (I did my best to update the docker setup accordingly).

Let me know how it looks