### PR TITLE
Add option to skip uWSGI config in Docker environments

### DIFF
--- a/docker/containers/tactical/entrypoint.sh
+++ b/docker/containers/tactical/entrypoint.sh
@@ -17,6 +17,7 @@ set -e
 : "${API_HOST:=tactical-backend}"
 : "${APP_HOST:=tactical-frontend}"
 : "${REDIS_HOST:=tactical-redis}"
+: "${SKIP_UWSGI_CONFIG:=0}"
 
 : "${CERT_PRIV_PATH:=${TACTICAL_DIR}/certs/privkey.pem}"
 : "${CERT_PUB_PATH:=${TACTICAL_DIR}/certs/fullchain.pem}"
@@ -121,7 +122,11 @@ EOF
   python manage.py load_community_scripts
   python manage.py reload_nats
   python manage.py create_natsapi_conf
-  python manage.py create_uwsgi_conf
+
+  if [ "$SKIP_UWSGI_CONFIG" = 0 ]; then
+    python manage.py create_uwsgi_conf
+  fi
+
   python manage.py create_installer_user
   python manage.py clear_redis_celery_locks
   python manage.py post_update_tasks


### PR DESCRIPTION
This PR adds the option to skip uWSGI config in Docker environments (to prevent user preferred uWSGI settings from being overwritten by the start script). If the parameter is set to anything other than the default (0), create_uwsgi_conf will not run.