### PR TITLE
Add gmail relay handling for emails

### DIFF
--- a/api/tacticalrmm/core/models.py
+++ b/api/tacticalrmm/core/models.py
@@ -221,6 +221,12 @@ class CoreSettings(BaseAuditModel):
                     )
                     server.send_message(msg)
                     server.quit()
+                if self.smtp_host == "smtp-relay.gmail.com" and not self.smtp_requires_auth:
+                    # gmail smtp relay specific handling.
+                    server.ehlo()
+                    server.starttls()
+                    server.send_message(msg)
+                    server.quit()
                 else:
                     # smtp relay. no auth required
                     server.send_message(msg)


### PR DESCRIPTION
This change adds ehlo and starttls functions when the server hostname is smtp-relay.gmail.com and authentication is disabled.  
Just sending the message and quitting isn't enough for gmail (google workspace) specifically.