### PR TITLE
Introducing Tactical RMM Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![CI Tests](https://github.com/amidaware/tacticalrmm/actions/workflows/ci-tests.yml/badge.svg?branch=develop)
 [![codecov](https://codecov.io/gh/amidaware/tacticalrmm/branch/develop/graph/badge.svg?token=8ACUPVPTH6)](https://codecov.io/gh/amidaware/tacticalrmm)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Tactical%20RMM%20Guru-006BFF)](https://gurubase.io/g/tactical-rmm)
 
 Tactical RMM is a remote monitoring & management tool, built with Django and Vue.\
 It uses an [agent](https://github.com/amidaware/rmmagent) written in golang and integrates with [MeshCentral](https://github.com/Ylianst/MeshCentral)


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Tactical RMM Guru](https://gurubase.io/g/tactical-rmm) to Gurubase. Tactical RMM Guru uses the data from this repo and data from the [docs](https://docs.tacticalrmm.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Tactical RMM Guru", which highlights that Tactical RMM now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Tactical RMM Guru in Gurubase, just let me know that's totally fine.