### PR TITLE
Make update.sh work with RHEL-based distros

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -434,7 +434,7 @@ if ! which npm >/dev/null; then
   if [[ "${ID_LIKE}" == *debian* ]]; then
     curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs
   elif [[ "${ID_LIKE}" == *rhel* ]]; then
-    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo $RHEL_PKG_MGR install -y nodejs
+    curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo -E bash - && sudo $RHEL_PKG_MGR install -y nodejs
   fi
   sudo npm install -g npm
 


### PR DESCRIPTION
The following changes are made:
* Uses `/etc/os-release` to determine OS type
* Uses `command -v dnf` to determine if `dnf` is available, and falls back to `yum` if not
* Uses `yum`/`dnf` in place of `apt` and `apt-get` where applicable
* Trades apt keyrings for yum GPG keys where applicable
* Changes `www-data` for `nginx` user/group where applicable
* Installs `pango` and `pango-devel` from proper sources when in a RHEL environment
* Uses `pyenv` to install proper python version when in RHEL environment
* Uses proper nodejs setup script and `dnf`/`yum` install when in a RHEL environment
* Changes `python manage.py` to `python3.11 manage.py` to be consistent
* Changes `/etc/nginx/sites-available` to `/etc/nginx/conf.d` when in a RHEL environment

The biggest change is the use of `pyenv` which required editing the service files, but it works well. This change could easily be added to the Debian section if desired, which would be less work than manually compiling the version each time.