### PR TITLE
Used THIS_SCRIPT variable within wget to allow execution from any dir.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -20,7 +20,7 @@ NEW_VER=$(grep "^SCRIPT_VERSION" "$TMP_FILE" | awk -F'[="]' '{print $3}')
 
 if [ "${SCRIPT_VERSION}" -ne "${NEW_VER}" ]; then
   printf >&2 "${YELLOW}Old update script detected, downloading and replacing with the latest version...${NC}\n"
-  wget -q "${SCRIPT_URL}" -O update.sh
+  wget -q "${SCRIPT_URL}" -O "${THIS_SCRIPT}"
   exec ${THIS_SCRIPT}
 fi
 


### PR DESCRIPTION
This is a very, very small change to the `update.sh` script that fixes an issue I originally referenced with #2162 where execution of the script from another directory (using a path like `./scripts/update.sh`) results in the script getting stuck in a loop when it needs an update. I looked into it, and found that was because the updated script was being saved in the shell's current directory, rather than overwriting the original script in its original location (so when the process starts over, it still has an out-of-date script, thus endless loop).

Since there is a variable used in the next command (`$THIS_SCRIPT`) that defines the full path and filename of the update script, I replaced the output flag in `wget` from `-o update.sh` to `-o "${THIS_SCRIPT}"` and it makes the update script function more narrowly defined, and safer than it is currently.

I realize it's taken longer to read this than it did to make the change itself, so I'll not waste any more of your time. If you feel this was worthwhile, thanks for accepting my PR. If not, I will presume you have your reasons, no worries. Keep up the great work.