### PR TITLE
Fixed duplicate hostnames in subject and include Client/Site in resolved email body

### DIFF
--- a/api/tacticalrmm/autotasks/models.py
+++ b/api/tacticalrmm/autotasks/models.py
@@ -532,7 +532,7 @@ class TaskResult(models.Model):
     )
 
     def __str__(self):
-        return f"{self.agent.hostname} - {self.task}"
+        return f"{self.task}"
 
     def get_or_create_alert_if_needed(
         self, alert_template: "Optional[AlertTemplate]"

--- a/api/tacticalrmm/checks/models.py
+++ b/api/tacticalrmm/checks/models.py
@@ -106,19 +106,19 @@ class Check(BaseAuditModel):
         default=list,
     )
     info_return_codes = ArrayField(
-        models.BigIntegerField(),
+        models.PositiveIntegerField(),
         null=True,
         blank=True,
         default=list,
     )
     warning_return_codes = ArrayField(
-        models.BigIntegerField(),
+        models.PositiveIntegerField(),
         null=True,
         blank=True,
         default=list,
     )
     success_return_codes = ArrayField(
-        models.PositiveBigIntegerField(),
+        models.PositiveIntegerField(),
         null=True,
         blank=True,
         default=list,
@@ -161,7 +161,7 @@ class Check(BaseAuditModel):
 
     def __str__(self):
         if self.agent:
-            return f"{self.agent.hostname} - {self.readable_desc}"
+            return f"{self.readable_desc}"
 
         return f"{self.policy.name} - {self.readable_desc}"
 
@@ -329,7 +329,7 @@ class CheckResult(models.Model):
     )
 
     def __str__(self):
-        return f"{self.agent.hostname} - {self.assigned_check}"
+        return f"{self.assigned_check}"
 
     def save(self, *args, **kwargs):
         # if check is a policy check clear cache on everything
@@ -663,7 +663,7 @@ class CheckResult(models.Model):
         CORE = get_core_settings()
 
         subject = f"{self.agent.client.name}, {self.agent.site.name}, {self} Resolved"
-        body = f"{self} is now back to normal"
+        body = f"{self.agent.client.name}, {self.agent.site.name}, {self} is now back to normal"
 
         CORE.send_mail(subject, body, alert_template=self.agent.alert_template)
 


### PR DESCRIPTION
Fixed duplicate hostnames in subject and include Client/Site in resolved email body

Fixes [#1936](https://github.com/BuddiesD/tacticalrmm/issues/1936)