### PR TITLE
Add CERT_BEHIND_PROXY setting to disable SSL certificate expiration warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ setup_dev.yml
 query_schema.json
 gunicorn_config.py
 set_local_config.py
+CLAUDE.local.md

--- a/api/tacticalrmm/tacticalrmm/helpers.py
+++ b/api/tacticalrmm/tacticalrmm/helpers.py
@@ -131,6 +131,10 @@ def make_random_password(*, len: int) -> str:
 
 
 def days_until_cert_expires() -> int:
+    # If SSL termination is handled by a proxy, return a high value to disable warnings
+    if getattr(settings, "CERT_BEHIND_PROXY", False):
+        return 999
+
     cert_file, _ = get_certs()
     cert_bytes = Path(cert_file).read_bytes()
 


### PR DESCRIPTION
## Summary
This PR adds support for a `CERT_BEHIND_PROXY` setting in `local_settings.py` to disable SSL certificate expiration warnings when SSL termination is handled by an external reverse proxy.

## Changes
- Modified `days_until_cert_expires()` function in `helpers.py` to check for the `CERT_BEHIND_PROXY` setting
- When set to `True`, the function returns 999 days instead of calculating actual certificate expiration
- This effectively disables the SSL certificate warning banner in the UI

## Use Case
This is useful for deployments where SSL termination occurs at a load balancer or reverse proxy layer (e.g., nginx, HAProxy, cloud load balancers), making the backend certificate expiration warnings irrelevant and potentially confusing.

## Usage
Add to `local_settings.py`:
```python
CERT_BEHIND_PROXY = True
```

## Testing
Tested on a production deployment with SSL termination at an external reverse proxy. The warning banner no longer appears in the UI after setting `CERT_BEHIND_PROXY = True` and restarting services.