### PR TITLE
Add allowedFramingOrigins for MeshCentral clickjacking protection

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     user: 1000:1000
     environment:
       MESH_HOST: ${MESH_HOST}
+      APP_HOST: ${APP_HOST}
       MESH_USER: ${MESH_USER}
       MESH_PASS: ${MESH_PASS}
       MONGODB_USER: ${MONGODB_USER}

--- a/ansible/roles/trmm_dev/templates/mesh.cfg.j2
+++ b/ansible/roles/trmm_dev/templates/mesh.cfg.j2
@@ -7,7 +7,7 @@
     "AliasPort": 443,
     "RedirPort": 800,
     "AllowLoginToken": true,
-    "AllowFraming": true,
+    "allowedFramingOrigins": ["https://{{ rmm }}", "http://{{ rmm }}:8080", "https://{{ rmm }}:8080"],
     "AgentPing": 35,
     "AllowHighQualityDesktop": true,
     "TlsOffload": "127.0.0.1",

--- a/docker/containers/tactical-meshcentral/entrypoint.sh
+++ b/docker/containers/tactical-meshcentral/entrypoint.sh
@@ -21,6 +21,12 @@ set -e
 : "${SMTP_PASS:=mesh-smtp-pass}"
 : "${SMTP_TLS:=false}"
 
+if [ -n "${APP_HOST}" ]; then
+  ALLOWED_FRAMING_ORIGINS='["https://'"${APP_HOST}"'"]'
+else
+  ALLOWED_FRAMING_ORIGINS='[]'
+fi
+
 if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTENT_CONFIG}" -eq 0 ]]; then
 
   encoded_uri=$(node -p "encodeURI('mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}')")
@@ -39,7 +45,7 @@ if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTE
     "agentAliasPort": 443,
     "aliasPort": 443,
     "allowLoginToken": true,
-    "allowFraming": true,
+    "allowedFramingOrigins": ${ALLOWED_FRAMING_ORIGINS},
     "agentPing": 35,
     "allowHighQualityDesktop": true,
     "agentCoreDump": false,

--- a/docker/containers/tactical-meshcentral/entrypoint.sh
+++ b/docker/containers/tactical-meshcentral/entrypoint.sh
@@ -22,6 +22,12 @@ set -e
 : "${SMTP_PASS:=mesh-smtp-pass}"
 : "${SMTP_TLS:=false}"
 
+if [ -n "${APP_HOST}" ]; then
+  ALLOWED_FRAMING_ORIGINS='["https://'"${APP_HOST}"'"]'
+else
+  ALLOWED_FRAMING_ORIGINS='[]'
+fi
+
 if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTENT_CONFIG}" -eq 0 ]]; then
 
   encoded_uri=$(node -p "encodeURI('mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}')")
@@ -40,7 +46,7 @@ if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTE
     "agentAliasPort": 443,
     "aliasPort": 443,
     "allowLoginToken": true,
-    "allowFraming": true,
+    "allowedFramingOrigins": ${ALLOWED_FRAMING_ORIGINS},
     "agentPing": 35,
     "allowHighQualityDesktop": true,
     "agentCoreDump": false,

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -105,6 +105,7 @@ services:
     restart: always
     environment:
       MESH_HOST: ${MESH_HOST}
+      APP_HOST: ${APP_HOST}
       MESH_USER: ${MESH_USER}
       MESH_PASS: ${MESH_PASS}
       MONGODB_USER: ${MONGODB_USER}

--- a/install.sh
+++ b/install.sh
@@ -448,7 +448,7 @@ meshcfg="$(
     "aliasPort": 443,
     "redirPort": 800,
     "allowLoginToken": true,
-    "allowFraming": true,
+    "allowedFramingOrigins": ["https://${frontenddomain}"],
     "agentPing": 35,
     "allowHighQualityDesktop": true,
     "tlsOffload": "127.0.0.1",

--- a/install.sh
+++ b/install.sh
@@ -447,7 +447,7 @@ meshcfg="$(
     "aliasPort": 443,
     "redirPort": 800,
     "allowLoginToken": true,
-    "allowFraming": true,
+    "allowedFramingOrigins": ["https://${frontenddomain}"],
     "agentPing": 35,
     "allowHighQualityDesktop": true,
     "tlsOffload": "127.0.0.1",

--- a/update.sh
+++ b/update.sh
@@ -663,6 +663,7 @@ if ! which jq >/dev/null; then
 fi
 
 if which jq >/dev/null; then
+  mesh_config_changed=false
   if ! jq -e "$check_jq_filter" "$mesh_cfg" >/dev/null; then
     echo "Disabling mesh compression"
     # backup to homedir first
@@ -671,10 +672,32 @@ if which jq >/dev/null; then
     if jq "$apply_jq_filter" "$mesh_cfg" >"$mesh_tmp"; then
       if [ -s "$mesh_tmp" ]; then
         mv "$mesh_tmp" "$mesh_cfg"
-        sudo systemctl restart meshcentral
+        mesh_config_changed=true
       fi
     fi
     rm -f "$mesh_tmp"
+  fi
+
+  # Migrate allowFraming to allowedFramingOrigins for clickjacking protection
+  if [ -f "$mesh_cfg" ] && [ -n "$FRONTEND" ]; then
+    has_allow_framing=$(jq -r '.settings | to_entries | map(.key | ascii_downcase) | index("allowframing") // "none"' "$mesh_cfg" 2>/dev/null)
+    has_allowed_origins=$(jq -r '.settings | to_entries | map(.key | ascii_downcase) | index("allowedframingorigins") // "none"' "$mesh_cfg" 2>/dev/null)
+    if [[ "$has_allow_framing" != "none" ]] && [[ "$has_allowed_origins" == "none" ]]; then
+      echo "Migrating MeshCentral config: replacing allowFraming with allowedFramingOrigins for clickjacking protection"
+      cp "$mesh_cfg" ~/meshcfg-framing-$(date "+%Y%m%dT%H%M%S").bak
+      mesh_tmp=$(mktemp)
+      if jq --arg frontend "$FRONTEND" '.settings |= ((to_entries | map(select((.key | ascii_downcase) != "allowframing")) | from_entries) + {"allowedFramingOrigins": ["https://\($frontend)"]})' "$mesh_cfg" >"$mesh_tmp" 2>/dev/null && [ -s "$mesh_tmp" ]; then
+        mv "$mesh_tmp" "$mesh_cfg"
+        mesh_config_changed=true
+      else
+        printf >&2 "${YELLOW}Warning: Could not migrate allowFraming to allowedFramingOrigins. Backup saved to ~/meshcfg-framing-*.bak${NC}\n"
+        rm -f "$mesh_tmp"
+      fi
+    fi
+  fi
+
+  if [[ "$mesh_config_changed" == "true" ]]; then
+    sudo systemctl restart meshcentral
   fi
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -376,6 +376,7 @@ if ! which jq >/dev/null; then
 fi
 
 if which jq >/dev/null; then
+  mesh_config_changed=false
   if ! jq -e "$check_jq_filter" "$mesh_cfg" >/dev/null; then
     echo "Disabling mesh compression"
     # backup to homedir first
@@ -384,6 +385,7 @@ if which jq >/dev/null; then
     if jq "$apply_jq_filter" "$mesh_cfg" >"$mesh_tmp"; then
       if [ -s "$mesh_tmp" ]; then
         mv "$mesh_tmp" "$mesh_cfg"
+        mesh_config_changed=true
       fi
     fi
     rm -f "$mesh_tmp"
@@ -395,6 +397,28 @@ if which jq >/dev/null; then
   mesh_tmp2=$(mktemp)
   if jq '.settings.autoBackup = false' "$mesh_cfg" >"$mesh_tmp2" && [ -s "$mesh_tmp2" ]; then
     mv "$mesh_tmp2" "$mesh_cfg"
+  fi
+
+  # Migrate allowFraming to allowedFramingOrigins for clickjacking protection
+  if [ -f "$mesh_cfg" ] && [ -n "$FRONTEND" ]; then
+    has_allow_framing=$(jq -r '.settings | to_entries | map(.key | ascii_downcase) | index("allowframing") // "none"' "$mesh_cfg" 2>/dev/null)
+    has_allowed_origins=$(jq -r '.settings | to_entries | map(.key | ascii_downcase) | index("allowedframingorigins") // "none"' "$mesh_cfg" 2>/dev/null)
+    if [[ "$has_allow_framing" != "none" ]] && [[ "$has_allowed_origins" == "none" ]]; then
+      echo "Migrating MeshCentral config: replacing allowFraming with allowedFramingOrigins for clickjacking protection"
+      cp "$mesh_cfg" ~/meshcfg-framing-$(date "+%Y%m%dT%H%M%S").bak
+      mesh_tmp=$(mktemp)
+      if jq --arg frontend "$FRONTEND" '.settings |= ((to_entries | map(select((.key | ascii_downcase) != "allowframing")) | from_entries) + {"allowedFramingOrigins": ["https://\($frontend)"]})' "$mesh_cfg" >"$mesh_tmp" 2>/dev/null && [ -s "$mesh_tmp" ]; then
+        mv "$mesh_tmp" "$mesh_cfg"
+        mesh_config_changed=true
+      else
+        printf >&2 "${YELLOW}Warning: Could not migrate allowFraming to allowedFramingOrigins. Backup saved to ~/meshcfg-framing-*.bak${NC}\n"
+        rm -f "$mesh_tmp"
+      fi
+    fi
+  fi
+
+  if [[ "$mesh_config_changed" == "true" ]]; then
+    sudo systemctl restart meshcentral
   fi
 fi
 


### PR DESCRIPTION
Replace `allowFraming` with `allowedFramingOrigins` for default config so only the TacticalRMM frontend can embed MeshCentral in iframes, addressing potential clickjacking. (See PR for MeshCentral changes https://github.com/Ylianst/MeshCentral/pull/7599, was released in [version 1.1.57](https://github.com/Ylianst/MeshCentral/releases/tag/1.1.57) of MeshCentral)

- install.sh: use `allowedFramingOrigins` with frontend domain
- Docker: add `allowedFramingOrigins` from `APP_HOST` (empty array if unset)
- Ansible mesh.cfg.j2: add `allowedFramingOrigins` for prod and dev (port 8080)
- update.sh: migrate existing `allowFraming` configs to `allowedFramingOrigins`
  - Skip when FRONTEND is empty or mesh config is missing
  - Add backup and warning on migration failure