### PR TITLE
WebVNC: pass resize=scale to noVNC for HiDPI/Retina hosts

### DIFF
--- a/api/tacticalrmm/agents/views.py
+++ b/api/tacticalrmm/agents/views.py
@@ -356,7 +356,7 @@ class WebVNC(APIView):
             + "%2F"
             + "meshrelay.ashx%3Fauth%3D"
             + cookie_ret["cookie"]  # type: ignore
-            + f"&show_dot=1&l=en&name={agent.hostname}"
+            + f"&show_dot=1&l=en&resize=scale&name={agent.hostname}"
         )
 
         ret = {


### PR DESCRIPTION
## Summary

The TRMM WebVNC ("Take Control" → web client) generates a noVNC URL without a `resize` parameter, so noVNC defaults to `resize=off`. On HiDPI hosts where the framebuffer is larger than the browser viewport this leaves the user looking at only a top-left fragment of the remote desktop, with no way to fit-to-window via the launch URL.

Concretely, on a Retina iMac M4 (logical 2240×1260 → physical 4480×2520) the visible browser viewport (~1080p) shows roughly the top-left quarter of the desktop, with the menubar starting mid-screen — see screenshot below.

## Fix

Append `resize=scale` to the existing query string in `WebVNC` view. noVNC will then CSS-scale the framebuffer to fit the viewport.

```diff
-            + f"&show_dot=1&l=en&name={agent.hostname}"
+            + f"&show_dot=1&l=en&resize=scale&name={agent.hostname}"
```

- One character of behavioural change (`resize=off` → `resize=scale`).
- No-op on regular-density hosts (1:1 mapping, scale=1).
- Supported by noVNC ≥ 1.1 — MeshCentral currently ships noVNC 1.5.0, so all in-the-wild TRMM installs cover this.
- Users can still override per-session via the noVNC settings drawer (left-edge handle) if they want native pixels.

## Why this isn't a frontend/user setting

The TRMM frontend redirects to MeshCentral's `/novnc/vnc.html`. The noVNC settings drawer toggle is per-tab and is lost on every reconnect, because the URL is regenerated from `WebVNC` view on each "Take Control" click. The URL is the only place a default can be set server-side.

## Reproduction

1. Onboard any Retina Mac (or any Windows host with display scaling > 100%) to TRMM.
2. Click "Take Control" → "WebVNC".
3. Observe: only a top-left fragment of the desktop is visible.

With the patch applied, the full desktop scales to fit the browser window.

## Testing

Tested live on production TRMM with iMac M4 (macOS Sequoia 15.3, arm64) — patch produces full-desktop view in the noVNC tab. Verified API response now contains `resize=scale` in the generated URL.

## Reference

- [noVNC URL parameters](https://github.com/novnc/noVNC/blob/master/docs/EMBEDDING.md) — `resize` accepts `off|scale|remote`