### PR TITLE
Security: Fix hardcoded default credentials in Docker env examples (CWE-798)

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -4,8 +4,8 @@ IMAGE_REPO=tacticalrmm/
 VERSION=latest
 
 # tactical credentials (Used to login to dashboard)
-TRMM_USER=tactical
-TRMM_PASS=tactical
+TRMM_USER=
+TRMM_PASS=
 
 # dns settings
 APP_HOST=rmm.example.com
@@ -13,14 +13,14 @@ API_HOST=api.example.com
 MESH_HOST=mesh.example.com
 
 # mesh settings
-MESH_USER=tactical
-MESH_PASS=tactical
+MESH_USER=
+MESH_PASS=
 MONGODB_USER=mongouser
-MONGODB_PASSWORD=mongopass
+MONGODB_PASSWORD=
 
 # database settings
-POSTGRES_USER=postgres
-POSTGRES_PASS=postgrespass
+POSTGRES_USER=
+POSTGRES_PASS=
 
 # DEV SETTINGS
 APP_PORT=443

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -2,8 +2,8 @@ IMAGE_REPO=tacticalrmm/
 VERSION=latest
 
 # tactical credentials (Used to login to dashboard)
-TRMM_USER=tactical
-TRMM_PASS=tactical
+TRMM_USER=
+TRMM_PASS=
 
 # optional web port override settings
 TRMM_HTTP_PORT=80
@@ -19,15 +19,15 @@ MESH_HOST=mesh.example.com
 # SESSION_COOKIE_DOMAIN=example.com
 
 # mesh settings
-MESH_USER=tactical
-MESH_PASS=tactical
+MESH_USER=
+MESH_PASS=
 MONGODB_USER=mongouser
-MONGODB_PASSWORD=mongopass
+MONGODB_PASSWORD=
 MESH_PERSISTENT_CONFIG=0
 
 # database settings
-POSTGRES_USER=postgres
-POSTGRES_PASS=postgrespass
+POSTGRES_USER=
+POSTGRES_PASS=
 
 # disable web terminal
 TRMM_DISABLE_WEB_TERMINAL=False


### PR DESCRIPTION
## Summary

The Docker environment example files (docker/.env.example and .devcontainer/.env.example) contain hardcoded default credentials:

- TRMM dashboard: tactical/tactical
- Mesh central: tactical/tactical
- MongoDB: mongouser/mongopass
- PostgreSQL: postgres/postgrespass

Users who deploy from these templates without changing the defaults would use known credentials that are publicly visible in the source code.

## Fix

Replace all hardcoded credential values with empty strings, requiring users to set their own values before deployment.
