### PR TITLE
Fix HTTP 500 when run_as_user is omitted from cmd/script POST payloads

### DIFF
--- a/api/tacticalrmm/agents/tests/test_agents.py
+++ b/api/tacticalrmm/agents/tests/test_agents.py
@@ -416,6 +416,42 @@ class TestAgentViews(TacticalTestCase):
 
         self.check_not_authenticated("post", url)
 
+    @patch("agents.models.Agent.run_script")
+    @patch("agents.models.Agent.nats_cmd")
+    def test_run_as_user_defaults_to_false_when_omitted(self, nats_cmd, run_script):
+        # API clients that predate the run_as_user field omit it from the
+        # payload. The field must default to False instead of raising
+        # KeyError -> HTTP 500. See send_raw_cmd / run_script.
+        nats_cmd.return_value = "ok"
+        run_script.return_value = "ok"
+
+        # /cmd/ (send_raw_cmd)
+        cmd_url = f"{base_url}/{self.agent.agent_id}/cmd/"
+        r = self.client.post(
+            cmd_url,
+            {"cmd": "ipconfig", "shell": "cmd", "timeout": 30},
+            format="json",
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(nats_cmd.call_args.args[0]["run_as_user"])
+
+        # /runscript/ (run_script)
+        script = baker.make_recipe("scripts.script")
+        run_url = f"{base_url}/{self.agent.agent_id}/runscript/"
+        r = self.client.post(
+            run_url,
+            {
+                "script": script.pk,
+                "output": "wait",
+                "args": [],
+                "timeout": 15,
+                "env_vars": [],
+            },
+            format="json",
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(run_script.call_args.kwargs["run_as_user"])
+
     @patch("agents.models.Agent.nats_cmd")
     def test_reboot_later(self, nats_cmd):
         nats_cmd.return_value = "ok"

--- a/api/tacticalrmm/agents/views.py
+++ b/api/tacticalrmm/agents/views.py
@@ -575,7 +575,7 @@ def send_raw_cmd(request, agent_id):
             "command": request.data["cmd"],
             "shell": shell,
         },
-        "run_as_user": request.data["run_as_user"],
+        "run_as_user": request.data.get("run_as_user", False),
     }
 
     hist = AgentHistory.objects.create(
@@ -876,7 +876,7 @@ def run_script(request, agent_id):
     script = get_object_or_404(Script, pk=request.data["script"])
     output = request.data["output"]
     args = request.data["args"]
-    run_as_user: bool = request.data["run_as_user"]
+    run_as_user: bool = request.data.get("run_as_user", False)
     env_vars: list[str] = request.data["env_vars"]
     req_timeout = int(request.data["timeout"]) + 3
     run_on_server: bool | None = request.data.get("run_on_server")
@@ -1139,7 +1139,7 @@ def bulk(request):
             shell=shell,
             timeout=request.data["timeout"],
             username=request.user.username[:50],
-            run_as_user=request.data["run_as_user"],
+            run_as_user=request.data.get("run_as_user", False),
         )
         return Response(f"Command will now be run on {len(agents)} agents. {ht}")
 
@@ -1162,7 +1162,7 @@ def bulk(request):
             args=request.data["args"],
             timeout=request.data["timeout"],
             username=request.user.username[:50],
-            run_as_user=request.data["run_as_user"],
+            run_as_user=request.data.get("run_as_user", False),
             env_vars=request.data["env_vars"],
             custom_field_pk=custom_field_pk,
             collector_all_output=collector_all_output,

--- a/api/tacticalrmm/scripts/tests.py
+++ b/api/tacticalrmm/scripts/tests.py
@@ -155,6 +155,25 @@ class TestScriptViews(TacticalTestCase):
 
         self.check_not_authenticated("post", url)
 
+    @patch("agents.models.Agent.nats_cmd", return_value="return value")
+    def test_test_script_run_as_user_defaults_to_false_when_omitted(self, nats_cmd):
+        # Older API clients omit run_as_user; it must default to False
+        # rather than raising KeyError -> HTTP 500.
+        agent = baker.make_recipe("agents.agent")
+        url = f"/scripts/{agent.agent_id}/test/"
+
+        data = {
+            "code": "some_code",
+            "timeout": 90,
+            "args": [],
+            "shell": ScriptShell.POWERSHELL,
+            "env_vars": [],
+        }
+
+        resp = self.client.post(url, data, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(nats_cmd.call_args.args[0]["run_as_user"])
+
     def test_delete_script(self):
         # test a call where script doesn't exist
         resp = self.client.delete("/scripts/500/", format="json")

--- a/api/tacticalrmm/scripts/views.py
+++ b/api/tacticalrmm/scripts/views.py
@@ -164,7 +164,7 @@ class TestScript(APIView):
                 "code": script_body,
                 "shell": request.data["shell"],
             },
-            "run_as_user": request.data["run_as_user"],
+            "run_as_user": request.data.get("run_as_user", False),
             "env_vars": parsed_env_vars,
             "nushell_enable_config": settings.NUSHELL_ENABLE_CONFIG,
             "deno_default_permissions": settings.DENO_DEFAULT_PERMISSIONS,

--- a/api/tacticalrmm/software/tests.py
+++ b/api/tacticalrmm/software/tests.py
@@ -244,3 +244,20 @@ class TestSoftwarePermissions(TacticalTestCase):
 
         # should work now
         self.check_authorized("post", url)
+
+    @patch("agents.models.Agent.nats_cmd")
+    def test_uninstall_software_run_as_user_defaults_to_false_when_omitted(
+        self, nats_cmd
+    ):
+        # Older API clients omit run_as_user; it must default to False
+        # rather than raising KeyError -> HTTP 500.
+        self.authenticate()
+        nats_cmd.return_value = "ok"
+        agent = baker.make_recipe("agents.agent")
+        url = f"{base_url}/{agent.agent_id}/uninstall/"
+
+        data = {"name": "Some App", "command": "msiexec /x {GUID} /qn", "timeout": 30}
+
+        resp = self.client.post(url, data, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(nats_cmd.call_args.args[0]["run_as_user"])

--- a/api/tacticalrmm/software/views.py
+++ b/api/tacticalrmm/software/views.py
@@ -115,7 +115,7 @@ class UninstallSoftware(APIView):
                 "command": uninstall_cmd,
                 "shell": "cmd",
             },
-            "run_as_user": request.data["run_as_user"],
+            "run_as_user": request.data.get("run_as_user", False),
         }
 
         hist = AgentHistory.objects.create(


### PR DESCRIPTION
## Problem

Six POST handlers read `request.data["run_as_user"]` by **direct index**, with no serializer backing the field. Any API client that doesn't send `run_as_user` gets an unhandled `KeyError`, which DRF turns into an **HTTP 500** instead of running the command/script:

| File | Handler | Endpoint |
|------|---------|----------|
| `agents/views.py` | `send_raw_cmd` | `POST /agents/{id}/cmd/` |
| `agents/views.py` | `run_script` | `POST /agents/{id}/runscript/` |
| `agents/views.py` | `bulk` (command) | `POST /agents/actions/bulk/` |
| `agents/views.py` | `bulk` (script) | `POST /agents/actions/bulk/` |
| `software/views.py` | `UninstallSoftware` | `POST /software/{id}/uninstall/` |
| `scripts/views.py` | `TestScript` | `POST /scripts/{id}/test/` |

The bundled web UI always sends the field, so this only bites REST API consumers (third-party integrations, custom scripts, MCP servers, anything written before `run_as_user` was added).

## Fix

Read the field as optional, defaulting to `False`:

```python
- request.data["run_as_user"]
+ request.data.get("run_as_user", False)
```

`False` isn't an arbitrary choice — it's already the canonical default for this field everywhere else in the codebase:

- `agents/consumers.py` already does `bool(content.get("run_as_user", False))` for the same field
- `Agent.run_script(...)`, `agents/tasks.py`, and `scripts/tasks.py` all default `run_as_user: bool = False`
- `Script.run_as_user` is a `BooleanField(default=False)`

So this makes the REST views consistent with the consumers, the model, and the tasks. It does **not** change escalation behaviour: where a *script* is flagged `run_as_user=True`, the existing `if script.run_as_user: run_as_user = True` logic still applies — this only sets the baseline when the **client** omits the field.

## Tests

Added regression tests that POST **without** `run_as_user` and assert a `200` plus a `False` value reaching the agent, for `/cmd/`, `/runscript/`, `/scripts/{id}/test/`, and `/software/{id}/uninstall/`.

Why this slipped through: the existing tests always sent `run_as_user`, and `test_uninstall_software` goes through `check_authorized()`, which wraps the request in `try/except KeyError` — so the very failure mode was being swallowed in the test suite.

Verified locally against `develop` with Python 3.11.8 + PostgreSQL 18 + Redis: `black --check` clean, `flake8` clean, target tests pass.
