### PR TITLE
Return script id on script creation

### DIFF
--- a/api/tacticalrmm/scripts/views.py
+++ b/api/tacticalrmm/scripts/views.py
@@ -48,7 +48,7 @@ class GetAddScripts(APIView):
 
         # obj.hash_script_body()
 
-        return Response(f"{obj.name} was added!")
+        return Response({"id": obj.id, "name": obj.name})
 
 
 class GetUpdateDeleteScript(APIView):


### PR DESCRIPTION
Changes the POST `/scripts/` response from a plain string to a JSON object containing the new script's `id` and `name`, enabling clients to reference the created script immediately.

```diff
- return Response(f"{obj.name} was added!")
+ return Response({"id": obj.id, "name": obj.name})
```