### PR TITLE
Change alert template re-alert interval from days to minutes

### DIFF
--- a/api/tacticalrmm/agents/tasks.py
+++ b/api/tacticalrmm/agents/tasks.py
@@ -59,7 +59,7 @@ def agent_outage_email_task(pk: int, alert_interval: Optional[float] = None) -> 
     else:
         if alert_interval:
             # send an email only if the last email sent is older than alert interval
-            delta = djangotime.now() - dt.timedelta(days=alert_interval)
+            delta = djangotime.now() - dt.timedelta(minutes=alert_interval)
             if alert.email_sent < delta:
                 sleep(rand_range(100, 1500))
                 alert.agent.send_outage_email()
@@ -104,7 +104,7 @@ def agent_outage_sms_task(pk: int, alert_interval: Optional[float] = None) -> st
     else:
         if alert_interval:
             # send an sms only if the last sms sent is older than alert interval
-            delta = djangotime.now() - dt.timedelta(days=alert_interval)
+            delta = djangotime.now() - dt.timedelta(minutes=alert_interval)
             if alert.sms_sent < delta:
                 sleep(rand_range(100, 1500))
                 alert.agent.send_outage_sms()

--- a/api/tacticalrmm/alerts/migrations/0015_rename_periodic_alert_days_to_minutes.py
+++ b/api/tacticalrmm/alerts/migrations/0015_rename_periodic_alert_days_to_minutes.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+
+
+def convert_days_to_minutes(apps, schema_editor):
+    AlertTemplate = apps.get_model("alerts", "AlertTemplate")
+    for obj in AlertTemplate.objects.all():
+        if obj.agent_periodic_alert_days:
+            obj.agent_periodic_alert_days = obj.agent_periodic_alert_days * 1440
+        if obj.check_periodic_alert_days:
+            obj.check_periodic_alert_days = obj.check_periodic_alert_days * 1440
+        if obj.task_periodic_alert_days:
+            obj.task_periodic_alert_days = obj.task_periodic_alert_days * 1440
+        obj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("alerts", "0014_alerttemplate_action_rest_alerttemplate_action_type_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            convert_days_to_minutes,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RenameField(
+            model_name="alerttemplate",
+            old_name="agent_periodic_alert_days",
+            new_name="agent_periodic_alert_minutes",
+        ),
+        migrations.RenameField(
+            model_name="alerttemplate",
+            old_name="check_periodic_alert_days",
+            new_name="check_periodic_alert_minutes",
+        ),
+        migrations.RenameField(
+            model_name="alerttemplate",
+            old_name="task_periodic_alert_days",
+            new_name="task_periodic_alert_minutes",
+        ),
+    ]

--- a/api/tacticalrmm/alerts/models.py
+++ b/api/tacticalrmm/alerts/models.py
@@ -331,7 +331,7 @@ class Alert(models.Model):
                 always_dashboard = alert_template.agent_always_alert
                 always_email = alert_template.agent_always_email
                 always_text = alert_template.agent_always_text
-                alert_interval = alert_template.agent_periodic_alert_days
+                alert_interval = alert_template.agent_periodic_alert_minutes
                 should_run_script_or_webhook = (
                     alert_template.agent_script_actions and alert_template.action
                 )
@@ -384,7 +384,7 @@ class Alert(models.Model):
                 always_dashboard = alert_template.check_always_alert
                 always_email = alert_template.check_always_email
                 always_text = alert_template.check_always_text
-                alert_interval = alert_template.check_periodic_alert_days
+                alert_interval = alert_template.check_periodic_alert_minutes
                 should_run_script_or_webhook = (
                     alert_template.check_script_actions and alert_template.action
                 )
@@ -420,7 +420,7 @@ class Alert(models.Model):
                 always_dashboard = alert_template.task_always_alert
                 always_email = alert_template.task_always_email
                 always_text = alert_template.task_always_text
-                alert_interval = alert_template.task_periodic_alert_days
+                alert_interval = alert_template.task_periodic_alert_minutes
                 should_run_script_or_webhook = (
                     alert_template.task_script_actions and alert_template.action
                 )
@@ -934,7 +934,7 @@ class AlertTemplate(BaseAuditModel):
     agent_always_email = BooleanField(null=True, blank=True, default=None)
     agent_always_text = BooleanField(null=True, blank=True, default=None)
     agent_always_alert = BooleanField(null=True, blank=True, default=None)
-    agent_periodic_alert_days = PositiveIntegerField(blank=True, null=True, default=0)
+    agent_periodic_alert_minutes = PositiveIntegerField(blank=True, null=True, default=0)
     # fmt: off
     agent_script_actions = BooleanField(null=True, blank=True, default=True)  # should be renamed because also deals with webhooks
 
@@ -959,7 +959,7 @@ class AlertTemplate(BaseAuditModel):
     check_always_email = BooleanField(null=True, blank=True, default=None)
     check_always_text = BooleanField(null=True, blank=True, default=None)
     check_always_alert = BooleanField(null=True, blank=True, default=None)
-    check_periodic_alert_days = PositiveIntegerField(blank=True, null=True, default=0)
+    check_periodic_alert_minutes = PositiveIntegerField(blank=True, null=True, default=0)
     # fmt: off
     check_script_actions = BooleanField(null=True, blank=True, default=True)  # should be renamed because also deals with webhooks
 
@@ -984,7 +984,7 @@ class AlertTemplate(BaseAuditModel):
     task_always_email = BooleanField(null=True, blank=True, default=None)
     task_always_text = BooleanField(null=True, blank=True, default=None)
     task_always_alert = BooleanField(null=True, blank=True, default=None)
-    task_periodic_alert_days = PositiveIntegerField(blank=True, null=True, default=0)
+    task_periodic_alert_minutes = PositiveIntegerField(blank=True, null=True, default=0)
     # fmt: off
     task_script_actions = BooleanField(null=True, blank=True, default=True)  # should be renamed because also deals with webhooks
 
@@ -1031,7 +1031,7 @@ class AlertTemplate(BaseAuditModel):
             or self.agent_always_email
             or self.agent_always_text
             or self.agent_always_alert
-            or bool(self.agent_periodic_alert_days)
+            or bool(self.agent_periodic_alert_minutes)
         )
 
     @property
@@ -1045,7 +1045,7 @@ class AlertTemplate(BaseAuditModel):
             or self.check_always_email
             or self.check_always_text
             or self.check_always_alert
-            or bool(self.check_periodic_alert_days)
+            or bool(self.check_periodic_alert_minutes)
         )
 
     @property
@@ -1059,7 +1059,7 @@ class AlertTemplate(BaseAuditModel):
             or self.task_always_email
             or self.task_always_text
             or self.task_always_alert
-            or bool(self.task_periodic_alert_days)
+            or bool(self.task_periodic_alert_minutes)
         )
 
     @property

--- a/api/tacticalrmm/alerts/tests.py
+++ b/api/tacticalrmm/alerts/tests.py
@@ -330,7 +330,7 @@ class TestAlertsViews(TacticalTestCase):
             "agent_always_email": True,
             "agent_always_text": True,
             "agent_always_alert": True,
-            "agent_periodic_alert_days": "90",
+            "agent_periodic_alert_minutes": "90",
         }
         resp = self.client.put(url, data, format="json")
         self.assertEqual(resp.status_code, 200)
@@ -566,13 +566,13 @@ class TestAlertTasks(TacticalTestCase):
             "alerts.AlertTemplate",
             is_active=True,
             agent_always_text=True,
-            agent_periodic_alert_days=5,
+            agent_periodic_alert_minutes=5,
         )
         alert_template_always_email = baker.make(
             "alerts.AlertTemplate",
             is_active=True,
             agent_always_email=True,
-            agent_periodic_alert_days=5,
+            agent_periodic_alert_minutes=5,
         )
 
         alert_template_blank = baker.make("alerts.AlertTemplate", is_active=True)
@@ -977,10 +977,10 @@ class TestAlertTasks(TacticalTestCase):
             Alert.objects.filter(assigned_check=check_template_email).count(), 1
         )
 
-        alert_template_email.check_periodic_alert_days = 1
+        alert_template_email.check_periodic_alert_minutes = 1
         alert_template_email.save()
 
-        alert_template_dashboard_text.check_periodic_alert_days = 1
+        alert_template_dashboard_text.check_periodic_alert_minutes = 1
         alert_template_dashboard_text.save()
 
         # set last email time for alert in the past
@@ -1285,10 +1285,10 @@ class TestAlertTasks(TacticalTestCase):
             Alert.objects.filter(assigned_task=task_template_email).count(), 1
         )
 
-        alert_template_email.task_periodic_alert_days = 1
+        alert_template_email.task_periodic_alert_minutes = 1
         alert_template_email.save()
 
-        alert_template_dashboard_text.task_periodic_alert_days = 1
+        alert_template_dashboard_text.task_periodic_alert_minutes = 1
         alert_template_dashboard_text.save()
 
         # set last email time for alert in the past

--- a/api/tacticalrmm/autotasks/tasks.py
+++ b/api/tacticalrmm/autotasks/tasks.py
@@ -175,7 +175,7 @@ def handle_task_email_alert(pk: int, alert_interval: Union[float, None] = None) 
     else:
         if alert_interval:
             # send an email only if the last email sent is older than alert interval
-            delta = djangotime.now() - dt.timedelta(days=alert_interval)
+            delta = djangotime.now() - dt.timedelta(minutes=alert_interval)
             if alert.email_sent < delta:
                 task_result = TaskResult.objects.get(
                     task=alert.assigned_task, agent=alert.agent
@@ -207,7 +207,7 @@ def handle_task_sms_alert(pk: int, alert_interval: Union[float, None] = None) ->
     else:
         if alert_interval:
             # send a text only if the last text sent is older than alert interval
-            delta = djangotime.now() - dt.timedelta(days=alert_interval)
+            delta = djangotime.now() - dt.timedelta(minutes=alert_interval)
             if alert.sms_sent < delta:
                 task_result = TaskResult.objects.get(
                     task=alert.assigned_task, agent=alert.agent

--- a/api/tacticalrmm/checks/tasks.py
+++ b/api/tacticalrmm/checks/tasks.py
@@ -32,7 +32,7 @@ def handle_check_email_alert_task(
     else:
         if alert_interval:
             # send an email only if the last email sent is older than alert interval
-            delta = djangotime.now() - dt.timedelta(days=alert_interval)
+            delta = djangotime.now() - dt.timedelta(minutes=alert_interval)
             if alert.email_sent < delta:
                 check_result = CheckResult.objects.get(
                     assigned_check=alert.assigned_check, agent=alert.agent
@@ -64,7 +64,7 @@ def handle_check_sms_alert_task(pk: int, alert_interval: Optional[float] = None)
     else:
         if alert_interval:
             # send a text only if the last text sent is older than 24 hours
-            delta = djangotime.now() - dt.timedelta(days=alert_interval)
+            delta = djangotime.now() - dt.timedelta(minutes=alert_interval)
             if alert.sms_sent < delta:
                 check_result = CheckResult.objects.get(
                     assigned_check=alert.assigned_check, agent=alert.agent


### PR DESCRIPTION
Closes #1771

Changes alert template re-alert interval from days to minutes, allowing intervals shorter than 24 hours.

- Renames `agent_periodic_alert_days` → `agent_periodic_alert_minutes` (same for check/task)
- Adds migration `0015` to rename fields and convert existing values (×1440 to preserve configured intervals)
- Updates Celery tasks: `dt.timedelta(days=…)` → `dt.timedelta(minutes=…)`
- Updates tests