### PR TITLE
Add toggleable Swagger API documentation

### DIFF
--- a/api/tacticalrmm/core/migrations/0056_coresettings_enable_swagger.py
+++ b/api/tacticalrmm/core/migrations/0056_coresettings_enable_swagger.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0055_coresettings_ssh_gateway_enable_exec_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="coresettings",
+            name="enable_swagger",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/api/tacticalrmm/core/models.py
+++ b/api/tacticalrmm/core/models.py
@@ -124,6 +124,7 @@ class CoreSettings(BaseAuditModel):
 
     block_local_user_logon = models.BooleanField(default=False)
     sso_enabled = models.BooleanField(default=False)
+    enable_swagger = models.BooleanField(default=False)
 
     default_shell_windows = models.CharField(
         max_length=32,
@@ -271,6 +272,10 @@ class CoreSettings(BaseAuditModel):
             return False
 
         return self.enable_server_webterminal
+
+    @property
+    def swagger_enabled(self) -> bool:
+        return self.enable_swagger
 
     def send_mail(
         self,

--- a/api/tacticalrmm/core/views.py
+++ b/api/tacticalrmm/core/views.py
@@ -157,6 +157,8 @@ def dashboard_info(request):
             "web_terminal_enabled": core_settings.web_terminal_enabled,
             "block_local_user_logon": core_settings.block_local_user_logon,
             "sso_enabled": core_settings.sso_enabled,
+            "swagger_enabled": core_settings.swagger_enabled,
+            "swagger_url": request.build_absolute_uri("/api/schema/swagger-ui/"),
         }
     )
 

--- a/api/tacticalrmm/tacticalrmm/settings.py
+++ b/api/tacticalrmm/tacticalrmm/settings.py
@@ -290,8 +290,7 @@ MIDDLEWARE = [
     "ee.sso.middleware.SSOIconMiddleware",
 ]
 
-if SWAGGER_ENABLED:
-    INSTALLED_APPS += ("drf_spectacular",)
+INSTALLED_APPS += ("drf_spectacular",)
 
 if DEBUG and not DEMO:
     INSTALLED_APPS.insert(0, "daphne")

--- a/api/tacticalrmm/tacticalrmm/urls.py
+++ b/api/tacticalrmm/tacticalrmm/urls.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.http import HttpResponseNotFound
 from django.urls import include, path, register_converter
 from knox import views as knox_views
 
@@ -66,17 +67,37 @@ if getattr(settings, "ADMIN_ENABLED", False):
 if getattr(settings, "DEBUG", False) and not getattr(settings, "DEMO", False):
     urlpatterns += [path("silk/", include("silk.urls", namespace="silk"))]
 
-if getattr(settings, "SWAGGER_ENABLED", False):
-    from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-    urlpatterns += (
-        path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-        path(
-            "api/schema/swagger-ui/",
-            SpectacularSwaggerView.as_view(url_name="schema"),
-            name="swagger-ui",
-        ),
-    )
+
+class SwaggerSpectacularAPIView(SpectacularAPIView):
+    def dispatch(self, request, *args, **kwargs):
+        from core.models import CoreSettings
+
+        cs = CoreSettings.objects.first()
+        if not cs or not cs.swagger_enabled:
+            return HttpResponseNotFound()
+        return super().dispatch(request, *args, **kwargs)
+
+
+class SwaggerSpectacularSwaggerView(SpectacularSwaggerView):
+    def dispatch(self, request, *args, **kwargs):
+        from core.models import CoreSettings
+
+        cs = CoreSettings.objects.first()
+        if not cs or not cs.swagger_enabled:
+            return HttpResponseNotFound()
+        return super().dispatch(request, *args, **kwargs)
+
+
+urlpatterns += (
+    path("api/schema/", SwaggerSpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/schema/swagger-ui/",
+        SwaggerSpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+)
 
 ws_urlpatterns = [
     path("ws/dashinfo/", DashInfo.as_asgi()),


### PR DESCRIPTION
## Add toggleable Swagger API documentation

Adds the ability to enable/disable Swagger API documentation via CoreSettings instead of a compile-time `SWAGGER_ENABLED` setting.

### Changes
- Add `enable_swagger` boolean field to `CoreSettings` model
- Add `swagger_enabled` property for cleaner access  
- Always load `drf_spectacular` app (removed conditional loading)
- Create `SwaggerSpectacularAPIView` and `SwaggerSpectacularSwaggerView` that check `CoreSettings.enable_swagger` before serving (returns **404** when disabled)
- Add `swagger_enabled` and `swagger_url` to `dashboard_info` endpoint
- Add migration `0056_coresettings_enable_swagger`

### Frontend PR
**Frontend:** https://github.com/amidaware/tacticalrmm-web/pull/53

### Future Improvements

- Improving the API schema documentation with better descriptions