### PR TITLE
fix(core): wait for MeshCentral node removal before closing the websocket

### DIFF
--- a/api/tacticalrmm/core/utils.py
+++ b/api/tacticalrmm/core/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import os
@@ -224,6 +225,28 @@ async def remove_mesh_agent(uri: str, mesh_node_id: str) -> None:
                 }
             )
         )
+        # MeshCentral acks the "removedevices" request immediately, but the
+        # actual node removal (db.Remove) happens in a *later* async callback
+        # (see meshuser.js, "removedevices" handler). Leaving the `async with`
+        # block right after send() closes the websocket before that callback
+        # runs, so the removal can be dropped and the node is left orphaned in
+        # the mesh database.
+        #
+        # Fix: keep the socket open until MeshCentral emits the "removenode"
+        # event, which it only fires once db.Remove has actually executed.
+        # Note we can't just do a single recv(): control.ashx pushes unsolicited
+        # frames (serverinfo/userinfo/...) before answering our request, so one
+        # recv() would grab the handshake's serverinfo and close too early. We
+        # drain incoming frames until the removenode event instead. Best-effort,
+        # bounded to 10s so a missing/renamed event can never hang the caller.
+        async def _wait_removenode() -> None:
+            async for message in ws:
+                r = json.loads(message)
+                if (r.get("event") or {}).get("action") == "removenode":
+                    return
+
+        with suppress(Exception):
+            await asyncio.wait_for(_wait_removenode(), timeout=10)
 
 
 def sysd_svc_is_running(svc: str) -> bool:


### PR DESCRIPTION
## What

Make `remove_mesh_agent` wait for MeshCentral to actually delete the node before it closes the websocket, so agent deletions don't leave orphaned nodes behind in the mesh database.

Thanks again for the project! While chasing down some stale/orphaned devices that lingered in MeshCentral after their agents had been deleted from Tactical, I traced it back to a small race in how we close the control socket. Here's the fix.

## The problem

`core.utils.remove_mesh_agent` opens a control websocket, sends `removedevices`, and returns:

```python
async def remove_mesh_agent(uri: str, mesh_node_id: str) -> None:
    node_id = _b64_to_hex(mesh_node_id)
    async with websockets.connect(uri) as ws:
        await ws.send(json.dumps({
            "action": "removedevices",
            "nodeids": [f"node//{node_id}"],
            "responseid": "trmm",
        }))
    # <-- the `async with` block ends here and the socket is closed
```

The catch is **when** MeshCentral does the work. On the `removedevices` action MeshCentral acknowledges the request almost immediately, but the real node removal (`db.Remove`) runs in a **later async callback** inside its `removedevices` handler (`meshuser.js`) — *after* the ack. Because `await ws.send(...)` only guarantees the frame was written to the socket, the `async with` block then exits and tears the connection down right away. If the connection closes before that deferred `db.Remove` callback fires, the removal is silently dropped and the node stays in the mesh DB — orphaned, since the agent no longer exists in Tactical to retry it.

It's timing-dependent, which is exactly why it looks intermittent: on a quiet server the callback usually wins the race; under load, or with any latency between Tactical and MeshCentral, it often doesn't.

## The fix

Keep the websocket open until MeshCentral tells us the node is actually gone. MeshCentral emits a `removenode` event **only once `db.Remove` has executed**, so that event is a reliable "it's really deleted now" signal. We drain incoming frames until we see it:

```python
async def _wait_removenode() -> None:
    async for message in ws:
        r = json.loads(message)
        if (r.get("event") or {}).get("action") == "removenode":
            return

with suppress(Exception):
    await asyncio.wait_for(_wait_removenode(), timeout=10)
```

Two details worth calling out:

- **Why not a single `recv()`?** `control.ashx` pushes unsolicited frames (`serverinfo`, `userinfo`, …) right after the handshake, before it answers our request. A lone `recv()` would just grab that `serverinfo` and return, closing the socket as early as before. Draining until the `removenode` event avoids that.
- **Bounded to 10s.** It's best-effort: if the event never arrives (server hiccup, a future rename of the event, etc.) `asyncio.wait_for` times out and we move on, so this can never hang the caller. The only new import is the stdlib `asyncio`.

No behavior change on the happy path beyond waiting a few extra milliseconds for the confirmation; the function still returns `None` and callers are unchanged.

## Testing

- Deleted agents repeatedly against a live MeshCentral instance: before the change the node intermittently survived in the mesh device list; after it, the node is consistently gone by the time the call returns.
- Confirmed the `removenode` event only shows up after the ack (not in the initial `serverinfo` burst), which is why draining — rather than a single read — is required.
- `python -m py_compile` on the module is clean.

## Related

This is one of the root causes behind orphaned / duplicate mesh devices reported in e.g. #708, #685 and #1553 — the deletion command was being issued but not reliably completing.
