### PR TITLE
fix(accounts): return 400 instead of 500 on malformed login requests

### DIFF
--- a/api/tacticalrmm/accounts/views.py
+++ b/api/tacticalrmm/accounts/views.py
@@ -111,7 +111,16 @@ class LoginViewV2(KnoxLoginView):
         if user.is_sso_user:
             return notify_error("Bad credentials")
 
-        token = request.data["twofactor"]
+        # A user who hasn't completed 2FA setup has no totp_key. Without this
+        # guard pyotp.TOTP("").verify(...) below raises and the endpoint returns
+        # an unhandled HTTP 500; return a clean "Bad credentials" 400 instead.
+        if not user.totp_key:
+            return notify_error("Bad credentials")
+
+        # Use .get() so a request missing the "twofactor" field returns the same
+        # clean 400 rather than a KeyError -> HTTP 500. An empty token simply
+        # fails verification below and falls through to "Bad credentials".
+        token = request.data.get("twofactor", "")
         totp = pyotp.TOTP(user.totp_key)
 
         if settings.DEBUG and token == "sekret":


### PR DESCRIPTION
## What

Make `LoginViewV2` return a clean `400 Bad credentials` instead of an unhandled `HTTP 500` when it receives a malformed login request.

Thanks again for the project! I hit a couple of 500s in the API logs coming from the v2 login endpoint while testing some edge cases, and both turned out to be unhandled exceptions on inputs that should just be rejected as bad credentials. Small hardening fix below.

## The problem

In `accounts.views.LoginViewV2.post`, after the credentials serializer validates, the code does:

```python
token = request.data["twofactor"]
totp = pyotp.TOTP(user.totp_key)
...
elif totp.verify(token, valid_window=10):
    valid = True
```

Two inputs make this raise instead of returning a normal response:

1. **User with valid username/password but no 2FA set up.** Such a user has an empty `totp_key`, so `pyotp.TOTP("").verify(...)` raises (base64 decode of an empty secret) → the request 500s instead of being rejected.
2. **Request body without a `twofactor` field.** `request.data["twofactor"]` raises `KeyError` → 500.

Neither is a server error — they're just malformed/incomplete login attempts that should get the same `Bad credentials` response every other failure path already returns. As-is they produce noisy 500s (and stack traces in the logs) that a client can trigger with a crafted POST.

## The fix

Guard both cases so they fall through to the existing clean 400:

```python
# empty totp_key -> reject instead of crashing pyotp
if not user.totp_key:
    return notify_error("Bad credentials")

# missing "twofactor" -> "" fails verification -> clean 400, no KeyError
token = request.data.get("twofactor", "")
totp = pyotp.TOTP(user.totp_key)
```

No behavior change for valid logins, and every rejection path still returns the identical `Bad credentials` message (so this doesn't leak whether the username/password was correct). No new imports.

## Testing

- POST valid username/password with no `twofactor` field → now `400 Bad credentials` (was `500`).
- POST for a user that hasn't completed TOTP enrollment → now `400 Bad credentials` (was `500`).
- Normal 2FA login with a correct token still succeeds; a wrong token still returns `400 Bad credentials`.
- `python -m py_compile` on the module is clean.
