### PR TITLE
fix/feature: site/client maintenance mode now requires every agent to be in maintenance mode

### DIFF
--- a/api/tacticalrmm/clients/tests.py
+++ b/api/tacticalrmm/clients/tests.py
@@ -206,6 +206,39 @@ class TestClientViews(TacticalTestCase):
 
         self.check_not_authenticated("delete", url)
 
+    def test_maintenance_mode_requires_all_agents(self):
+        client = baker.make("clients.Client")
+        site = baker.make("clients.Site", client=client)
+        other_site = baker.make("clients.Site", client=client)
+
+        agent_1 = baker.make_recipe("agents.agent", site=site)
+        agent_2 = baker.make_recipe("agents.agent", site=site)
+        agent_3 = baker.make_recipe("agents.agent", site=other_site)
+
+        agent_1.maintenance_mode = True
+        agent_1.save(update_fields=["maintenance_mode"])
+
+        response = self.client.get(f"{base_url}/", format="json")
+
+        self.assertEqual(response.status_code, 200)
+        client_data = next(item for item in response.data if item["id"] == client.id)
+        site_data = next(item for item in client_data["sites"] if item["id"] == site.id)
+
+        self.assertFalse(site_data["maintenance_mode"])
+        self.assertFalse(client_data["maintenance_mode"])
+
+        agent_2.maintenance_mode = True
+        agent_2.save(update_fields=["maintenance_mode"])
+        agent_3.maintenance_mode = True
+        agent_3.save(update_fields=["maintenance_mode"])
+
+        response = self.client.get(f"{base_url}/", format="json")
+        client_data = next(item for item in response.data if item["id"] == client.id)
+        site_data = next(item for item in client_data["sites"] if item["id"] == site.id)
+
+        self.assertTrue(site_data["maintenance_mode"])
+        self.assertTrue(client_data["maintenance_mode"])
+
     def test_get_sites(self):
         # setup data
         baker.make("clients.Site", _quantity=5)

--- a/api/tacticalrmm/clients/views.py
+++ b/api/tacticalrmm/clients/views.py
@@ -4,7 +4,16 @@ import uuid
 from contextlib import suppress
 
 from django.conf import settings
-from django.db.models import Count, Exists, OuterRef, Prefetch, prefetch_related_objects
+from django.db.models import (
+    BooleanField,
+    Case,
+    Count,
+    Exists,
+    OuterRef,
+    Prefetch,
+    When,
+    prefetch_related_objects,
+)
 from django.shortcuts import get_object_or_404
 from django.utils import timezone as djangotime
 from knox.models import AuthToken
@@ -48,25 +57,39 @@ class GetAddClients(APIView):
                     .select_related("client")
                     .filter_by_role(request.user)
                     .prefetch_related("custom_fields__field")
+                    .annotate(agent_count=Count("agents"))
                     .annotate(
-                        maintenance_mode=Exists(
-                            Agent.objects.filter(
-                                site=OuterRef("pk"), maintenance_mode=True
-                            )
+                        maintenance_mode=Case(
+                            When(
+                                agent_count__gt=0,
+                                then=~Exists(
+                                    Agent.objects.filter(site=OuterRef("pk")).exclude(
+                                        maintenance_mode=True
+                                    )
+                                ),
+                            ),
+                            default=False,
+                            output_field=BooleanField(),
                         )
-                    )
-                    .annotate(agent_count=Count("agents")),
+                    ),
                     to_attr="filtered_sites",
                 ),
             )
+            .annotate(agent_count=Count("sites__agents"))
             .annotate(
-                maintenance_mode=Exists(
-                    Agent.objects.filter(
-                        site__client=OuterRef("pk"), maintenance_mode=True
-                    )
+                maintenance_mode=Case(
+                    When(
+                        agent_count__gt=0,
+                        then=~Exists(
+                            Agent.objects.filter(site__client=OuterRef("pk")).exclude(
+                                maintenance_mode=True
+                            )
+                        ),
+                    ),
+                    default=False,
+                    output_field=BooleanField(),
                 )
             )
-            .annotate(agent_count=Count("sites__agents"))
         )
         return Response(ClientSerializer(clients, many=True).data)
 
@@ -126,12 +149,21 @@ class GetUpdateDeleteClient(APIView):
                 .select_related("client")
                 .filter_by_role(request.user)
                 .prefetch_related("custom_fields__field")
+                .annotate(agent_count=Count("agents"))
                 .annotate(
-                    maintenance_mode=Exists(
-                        Agent.objects.filter(site=OuterRef("pk"), maintenance_mode=True)
+                    maintenance_mode=Case(
+                        When(
+                            agent_count__gt=0,
+                            then=~Exists(
+                                Agent.objects.filter(site=OuterRef("pk")).exclude(
+                                    maintenance_mode=True
+                                )
+                            ),
+                        ),
+                        default=False,
+                        output_field=BooleanField(),
                     )
-                )
-                .annotate(agent_count=Count("agents")),
+                ),
                 to_attr="filtered_sites",
             ),
         )


### PR DESCRIPTION
## Summary

This PR fixes the maintenance mode indicator to only display when a client or site is indeed fully in maintenance mode. 
Previously, the indicator was shown whenever any agent was in maintenance mode, which could be misleading. (it really bugs me, maybe its a feature request?)

## Changes

* changes the `maintenance_mode` annotation from `Exists` to `Case/When`
* updates the logic so a client/site is only marked as being in maintenance mode when **all** of its agents are in maintenance mode

## Notes

Current (this PR):

<img width="945" height="238" alt="image" src="https://github.com/user-attachments/assets/9785ca6e-cc1a-4fab-8d3f-02c1ade1a27b" />
<img width="945" height="184" alt="image" src="https://github.com/user-attachments/assets/526e1612-ef85-4090-ac60-32bfa75fa08a" />
<img width="945" height="196" alt="image" src="https://github.com/user-attachments/assets/3a81c591-5ca8-4ad6-a117-083fa5179197" />


I also experimented with a few alternative designs:

Only display the maintenance icon when all agents within a site/client are in maintenance mode:
<img width="300" height="143" alt="image" src="https://github.com/user-attachments/assets/94e501ae-7dd1-47b3-859c-5b084bc75e69" />
Display a maintenance icon in the corner when one or more agents in a site/client are in maintenance mode:
<img width="210" height="145" alt="image" src="https://github.com/user-attachments/assets/37386b35-2f99-4fd2-bd0b-eedbfb95c7ff" />
<img width="210" height="150" alt="image" src="https://github.com/user-attachments/assets/06bf676c-4ef1-481c-969d-f20118a85343" />

please ignore the different sizes and styles caused by different browsers 😅



I'm not sure which approach is preferred. If desired, we could include multiple display options and make the behavior configurable through the settings.


a ❤️ for the TRMM Dev's