### PR TITLE
Add send conditions to report schedules

### DIFF
--- a/api/tacticalrmm/ee/reporting/migrations/0005_reportschedule_conditions_and_last_run_status.py
+++ b/api/tacticalrmm/ee/reporting/migrations/0005_reportschedule_conditions_and_last_run_status.py
@@ -1,0 +1,43 @@
+# Generated manually for report schedule send conditions
+
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reporting", "0004_reportdataquery_created_by_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="reportschedule",
+            name="conditions",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.TextField(),
+                blank=True,
+                default=list,
+                size=None,
+            ),
+        ),
+        migrations.AddField(
+            model_name="reportschedule",
+            name="last_run_message",
+            field=models.CharField(blank=True, default="", max_length=500),
+        ),
+        migrations.AddField(
+            model_name="reportschedule",
+            name="last_run_status",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("success", "Success"),
+                    ("skipped", "Skipped"),
+                    ("error", "Error"),
+                ],
+                default="",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/api/tacticalrmm/ee/reporting/models.py
+++ b/api/tacticalrmm/ee/reporting/models.py
@@ -75,6 +75,12 @@ class ReportRunFormat(models.TextChoices):
     PLAINTEXT = "plaintext", "Plain Text"
 
 
+class ReportScheduleLastRunStatus(models.TextChoices):
+    SUCCESS = "success", "Success"
+    SKIPPED = "skipped", "Skipped"
+    ERROR = "error", "Error"
+
+
 class ReportSchedule(BaseAuditModel):
 
     name = models.CharField(
@@ -100,6 +106,11 @@ class ReportSchedule(BaseAuditModel):
     )
 
     dependencies = models.JSONField(default=dict)
+    conditions = ArrayField(
+        models.TextField(),
+        blank=True,
+        default=list,
+    )
     email_recipients = ArrayField(
         base_field=models.EmailField(),
         blank=True,
@@ -107,6 +118,13 @@ class ReportSchedule(BaseAuditModel):
     )
     send_report_email = models.BooleanField(default=True)
     last_run = models.DateTimeField(null=True, blank=True)
+    last_run_status = models.CharField(
+        max_length=20,
+        choices=ReportScheduleLastRunStatus.choices,
+        blank=True,
+        default="",
+    )
+    last_run_message = models.CharField(max_length=500, blank=True, default="")
     locked_at = models.DateTimeField(null=True, blank=True)
     email_settings = models.JSONField(default=dict)
     timezone = models.CharField(max_length=100, null=True, blank=True)

--- a/api/tacticalrmm/ee/reporting/serializers.py
+++ b/api/tacticalrmm/ee/reporting/serializers.py
@@ -21,4 +21,5 @@ class ReportScheduleAuditSerializer(ModelSerializer):
             "send_report_email",
             "email_settings",
             "timezone",
+            "conditions",
         ]

--- a/api/tacticalrmm/ee/reporting/tasks.py
+++ b/api/tacticalrmm/ee/reporting/tasks.py
@@ -106,12 +106,18 @@ def scheduled_reports_runner():
 
     for report in run_list:
         try:
-            _, error = run_scheduled_report(schedule=report)
+            result = run_scheduled_report(schedule=report)
         except Exception as e:
             logger.error(str(e))
         else:
-            if error:
-                logger.error(error)
+            if result.status == "error" and result.error:
+                logger.error(result.error)
+            elif result.status == "skipped":
+                logger.info(
+                    "Report schedule %s skipped: %s",
+                    report.pk,
+                    result.message or "condition",
+                )
 
 
 @app.task

--- a/api/tacticalrmm/ee/reporting/tests/test_report_schedule_views.py
+++ b/api/tacticalrmm/ee/reporting/tests/test_report_schedule_views.py
@@ -5,6 +5,7 @@ from rest_framework.test import APIClient
 from model_bakery import baker
 
 from ..models import ReportSchedule, ReportHistory, ReportTemplate
+from ..utils import ScheduledReportRunResult
 from core.models import Schedule
 
 
@@ -93,7 +94,10 @@ class TestReportScheduleViews:
 
 @pytest.mark.django_db
 class TestRunReportScheduleView:
-    @patch("ee.reporting.views.run_scheduled_report", return_value=(None, None))
+    @patch(
+        "ee.reporting.views.run_scheduled_report",
+        return_value=ScheduledReportRunResult(status="success"),
+    )
     def test_run_schedule_success(
         self, mock_run, authenticated_client, report_schedule
     ):
@@ -101,13 +105,16 @@ class TestRunReportScheduleView:
         response = authenticated_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "success"
         mock_run.assert_called_once_with(
             schedule=report_schedule, user=authenticated_client.handler._force_user
         )
 
     @patch(
         "ee.reporting.views.run_scheduled_report",
-        return_value=(None, "Something went wrong"),
+        return_value=ScheduledReportRunResult(
+            status="error", error="Something went wrong"
+        ),
     )
     def test_run_schedule_with_error(
         self, mock_run, authenticated_client, report_schedule

--- a/api/tacticalrmm/ee/reporting/tests/test_schedule_conditions.py
+++ b/api/tacticalrmm/ee/reporting/tests/test_schedule_conditions.py
@@ -1,0 +1,337 @@
+"""
+Copyright (c) 2023-present Amidaware Inc.
+This file is subject to the EE License Agreement.
+For details, see: https://license.tacticalrmm.com/ee
+"""
+
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from ..models import ReportHistory, ReportSchedule, ReportTemplate
+from ..utils import (
+    ScheduledReportRunResult,
+    data_source_keys_referenced_by,
+    run_scheduled_report,
+)
+from core.models import Schedule
+
+
+@pytest.fixture
+def authenticated_client():
+    client = APIClient()
+    user = baker.make("accounts.User", is_superuser=True)
+    client.force_authenticate(user=user)
+    return client
+
+
+class TestDataSourceKeysReferencedBy:
+    def test_attr_and_item_access(self):
+        keys = data_source_keys_referenced_by(
+            [
+                "data_sources.foo|length > 0",
+                'data_sources["bar"] > 1',
+                "data_sources['baz']",
+            ]
+        )
+        assert keys == {"foo", "bar", "baz"}
+
+    def test_bare_data_sources_means_all(self):
+        assert data_source_keys_referenced_by(["data_sources"]) is None
+
+    def test_no_data_sources_returns_empty(self):
+        assert data_source_keys_referenced_by(["True", "1 > 0"]) == set()
+
+
+@pytest.mark.django_db
+class TestRunScheduledReportConditions:
+    @pytest.fixture
+    def template(self):
+        return baker.make(
+            ReportTemplate,
+            template_md="Hello",
+            type="markdown",
+            template_variables="",
+        )
+
+    @pytest.fixture
+    def schedule(self, template):
+        return baker.make(
+            ReportSchedule,
+            report_template=template,
+            schedule=baker.make(Schedule),
+            format="html",
+            send_report_email=True,
+            conditions=[],
+            dependencies={},
+        )
+
+    @patch("ee.reporting.tasks.email_report.delay")
+    @patch("ee.reporting.utils.run_report")
+    def test_empty_conditions_uses_normal_path(
+        self, mock_run_report, mock_email, schedule
+    ):
+        history = baker.make(ReportHistory, report_template=schedule.report_template)
+        mock_run_report.return_value = ("<html></html>", None, history)
+
+        result = run_scheduled_report(schedule=schedule)
+
+        assert result.status == "success"
+        mock_run_report.assert_called_once()
+        assert mock_run_report.call_args.kwargs["prepared_variables"] is None
+        mock_email.assert_called_once()
+        schedule.refresh_from_db()
+        assert schedule.last_run_status == "success"
+
+    @patch("ee.reporting.tasks.email_report.delay")
+    @patch("ee.reporting.utils.process_chart_variables")
+    @patch("ee.reporting.utils.process_data_sources")
+    @patch("ee.reporting.utils.prep_variables_for_template")
+    @patch("ee.reporting.utils.run_report")
+    def test_falsy_condition_skips_without_email_or_history(
+        self,
+        mock_run_report,
+        mock_prep,
+        mock_process_ds,
+        mock_charts,
+        mock_email,
+        schedule,
+    ):
+        schedule.conditions = ["False"]
+        schedule.save(update_fields=["conditions"])
+        mock_prep.return_value = {"data_sources": {}}
+
+        result = run_scheduled_report(schedule=schedule)
+
+        assert result.status == "skipped"
+        assert result.skip_index == 0
+        mock_run_report.assert_not_called()
+        mock_process_ds.assert_not_called()
+        mock_charts.assert_not_called()
+        mock_email.assert_not_called()
+        assert ReportHistory.objects.count() == 0
+        schedule.refresh_from_db()
+        assert schedule.last_run_status == "skipped"
+        assert schedule.last_run is not None
+
+    @patch("ee.reporting.tasks.email_report.delay")
+    @patch("ee.reporting.utils.process_chart_variables", side_effect=lambda **kw: kw["variables"])
+    @patch("ee.reporting.utils.process_data_sources", side_effect=lambda **kw: kw["variables"])
+    @patch("ee.reporting.utils.prep_variables_for_template")
+    @patch("ee.reporting.utils.run_report")
+    def test_truthy_condition_passes_and_reuses_prepared_variables(
+        self,
+        mock_run_report,
+        mock_prep,
+        mock_process_ds,
+        mock_charts,
+        mock_email,
+        schedule,
+    ):
+        schedule.conditions = ["True"]
+        schedule.save(update_fields=["conditions"])
+        prepared = {"data_sources": {"foo": []}}
+        mock_prep.return_value = prepared
+        history = baker.make(ReportHistory, report_template=schedule.report_template)
+        mock_run_report.return_value = ("<html></html>", None, history)
+
+        result = run_scheduled_report(schedule=schedule)
+
+        assert result.status == "success"
+        mock_prep.assert_called_once()
+        assert mock_prep.call_args.kwargs["include_charts"] is False
+        mock_process_ds.assert_called_once()
+        mock_charts.assert_called_once()
+        assert mock_run_report.call_args.kwargs["prepared_variables"] is prepared
+        mock_email.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "expression",
+        ["undefined_name", "undefined_name|length > 0"],
+    )
+    @patch("ee.reporting.tasks.email_report.delay")
+    @patch("ee.reporting.utils.prep_variables_for_template")
+    @patch("ee.reporting.utils.run_report")
+    def test_condition_exception_is_error_not_skip(
+        self, mock_run_report, mock_prep, mock_email, schedule, expression
+    ):
+        schedule.conditions = [expression]
+        schedule.save(update_fields=["conditions"])
+        mock_prep.return_value = {}
+
+        result = run_scheduled_report(schedule=schedule)
+
+        assert result.status == "error"
+        assert result.error
+        mock_run_report.assert_not_called()
+        mock_email.assert_not_called()
+        schedule.refresh_from_db()
+        assert schedule.last_run_status == "error"
+
+    @patch("ee.reporting.tasks.email_report.delay")
+    @patch("ee.reporting.utils.prep_variables_for_template")
+    @patch("ee.reporting.utils.run_report")
+    def test_defined_none_is_skip_not_error(
+        self, mock_run_report, mock_prep, mock_email, schedule
+    ):
+        schedule.conditions = ["value"]
+        schedule.save(update_fields=["conditions"])
+        mock_prep.return_value = {"value": None}
+
+        result = run_scheduled_report(schedule=schedule)
+
+        assert result.status == "skipped"
+        mock_run_report.assert_not_called()
+        mock_email.assert_not_called()
+
+    @patch("ee.reporting.tasks.email_report.delay")
+    @patch("ee.reporting.utils.run_report")
+    def test_render_error_does_not_email(self, mock_run_report, mock_email, schedule):
+        history = baker.make(
+            ReportHistory,
+            report_template=schedule.report_template,
+            error_data="boom",
+        )
+        mock_run_report.return_value = (None, "boom", history)
+
+        result = run_scheduled_report(schedule=schedule)
+
+        assert result.status == "error"
+        mock_email.assert_not_called()
+        schedule.refresh_from_db()
+        assert schedule.last_run_status == "error"
+    @patch("ee.reporting.utils.build_queryset")
+    @patch("ee.reporting.utils.process_chart_variables")
+    def test_skip_only_loads_referenced_data_sources(
+        self, mock_charts, mock_build_queryset, schedule
+    ):
+        schedule.report_template.template_variables = """
+data_sources:
+  foo:
+    model: agent
+    only: [hostname]
+  bar:
+    model: agent
+    only: [hostname]
+"""
+        schedule.report_template.save(update_fields=["template_variables"])
+        schedule.conditions = ["data_sources.foo|length > 0"]
+        schedule.save(update_fields=["conditions"])
+        mock_build_queryset.return_value = []
+
+        result = run_scheduled_report(schedule=schedule)
+
+        assert result.status == "skipped"
+        assert mock_build_queryset.call_count == 1
+        mock_charts.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestReportScheduleConditionsAPI:
+    def test_create_schedule_with_conditions(self, authenticated_client):
+        template = baker.make(ReportTemplate)
+        schedule = baker.make(Schedule)
+        payload = {
+            "name": "Conditional Schedule",
+            "report_template": template.pk,
+            "schedule": schedule.pk,
+            "format": "html",
+            "send_report_email": True,
+            "conditions": ["data_sources.agents|length > 0"],
+        }
+        response = authenticated_client.post(
+            "/reporting/schedules/", payload, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["conditions"] == ["data_sources.agents|length > 0"]
+        created = ReportSchedule.objects.get(pk=response.data["id"])
+        assert created.conditions == ["data_sources.agents|length > 0"]
+
+    def test_create_schedule_rejects_invalid_condition(self, authenticated_client):
+        template = baker.make(ReportTemplate)
+        schedule = baker.make(Schedule)
+        payload = {
+            "name": "Bad Condition",
+            "report_template": template.pk,
+            "schedule": schedule.pk,
+            "format": "html",
+            "conditions": ["{% for x in y %}{{ x }}{% endfor %}"],
+        }
+        response = authenticated_client.post(
+            "/reporting/schedules/", payload, format="json"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_without_conditions_defaults_empty(self, authenticated_client):
+        template = baker.make(ReportTemplate)
+        schedule = baker.make(Schedule)
+        payload = {
+            "name": "No Conditions",
+            "report_template": template.pk,
+            "schedule": schedule.pk,
+            "format": "pdf",
+            "send_report_email": True,
+        }
+        response = authenticated_client.post(
+            "/reporting/schedules/", payload, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["conditions"] == []
+
+
+@pytest.mark.django_db
+class TestRunReportScheduleViewConditions:
+    @pytest.fixture
+    def report_schedule(self):
+        return baker.make(ReportSchedule)
+
+    @patch(
+        "ee.reporting.views.run_scheduled_report",
+        return_value=ScheduledReportRunResult(status="success"),
+    )
+    def test_run_schedule_success(
+        self, mock_run, authenticated_client, report_schedule
+    ):
+        url = f"/reporting/schedules/{report_schedule.id}/run/"
+        response = authenticated_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "success"
+        mock_run.assert_called_once()
+
+    @patch(
+        "ee.reporting.views.run_scheduled_report",
+        return_value=ScheduledReportRunResult(
+            status="skipped", skip_index=0, message="Condition 1 was not true"
+        ),
+    )
+    def test_run_schedule_skipped(
+        self, mock_run, authenticated_client, report_schedule
+    ):
+        url = f"/reporting/schedules/{report_schedule.id}/run/"
+        response = authenticated_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["status"] == "skipped"
+        assert response.data["index"] == 0
+
+    @patch(
+        "ee.reporting.views.run_scheduled_report",
+        return_value=ScheduledReportRunResult(
+            status="error", error="Something went wrong"
+        ),
+    )
+    def test_run_schedule_with_error(
+        self, mock_run, authenticated_client, report_schedule
+    ):
+        url = f"/reporting/schedules/{report_schedule.id}/run/"
+        response = authenticated_client.post(url)
+
+        assert response.status_code == 400
+        assert response.data == "Something went wrong"

--- a/api/tacticalrmm/ee/reporting/utils.py
+++ b/api/tacticalrmm/ee/reporting/utils.py
@@ -10,9 +10,11 @@ import json
 import re
 from enum import Enum
 from types import SimpleNamespace
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
+    Collection,
     Dict,
     List,
     Literal,
@@ -28,9 +30,9 @@ import yaml
 from django.apps import apps
 from django.conf import settings
 from django.utils import timezone as djangotime
-from jinja2 import FunctionLoader
+from jinja2 import FunctionLoader, StrictUndefined, Undefined
 from jinja2.sandbox import SandboxedEnvironment
-from jinja2.exceptions import TemplateError
+from jinja2.exceptions import TemplateError, UndefinedError
 from rest_framework.serializers import ValidationError
 from weasyprint import CSS, HTML
 from weasyprint.text.fonts import FontConfiguration
@@ -59,6 +61,18 @@ RE_ASSET_URL = re.compile(
 )
 
 RE_DEPENDENCY_VALUE = re.compile(r"(\{\{\s*(.*)\s*\}\})")
+
+RE_DATA_SOURCE_ATTR = re.compile(r"data_sources\.([A-Za-z_][A-Za-z0-9_]*)")
+RE_DATA_SOURCE_ITEM = re.compile(r"data_sources\[\s*(['\"])(.*?)\1\s*\]")
+
+
+@dataclass
+class ScheduledReportRunResult:
+    status: Literal["success", "skipped", "error"]
+    history: Optional["ReportHistory"] = None
+    error: Optional[str] = None
+    skip_index: Optional[int] = None
+    message: Optional[str] = None
 
 
 def public_mod(module):
@@ -106,6 +120,10 @@ env.globals.update(custom_globals)
 for name, func in inspect.getmembers(custom_filters, inspect.isfunction):
     env.filters[name] = func
 
+# Default Undefined is falsy, so a typo like `undefined_name` would skip
+# instead of erroring. Conditions must fail closed on missing names.
+condition_env = env.overlay(undefined=StrictUndefined)
+
 
 def generate_pdf(*, html: str, css: str = "") -> bytes:
     font_config = FontConfiguration()
@@ -126,6 +144,7 @@ def generate_html(
     variables: str = "",
     dependencies: Optional[Dict[str, int]] = None,
     user: Optional["User"] = None,
+    prepared_variables: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, Dict[str, Any]]:
     if dependencies is None:
         dependencies = {}
@@ -150,9 +169,12 @@ def generate_html(
 
     tm = env.from_string(template_string)
 
-    variables_dict = prep_variables_for_template(
-        variables=variables, dependencies=dependencies, user=user
-    )
+    if prepared_variables is not None:
+        variables_dict = prepared_variables
+    else:
+        variables_dict = prep_variables_for_template(
+            variables=variables, dependencies=dependencies, user=user
+        )
 
     return (tm.render(css=css, **variables_dict), variables_dict)
 
@@ -176,12 +198,32 @@ def make_dataqueries_inline(*, variables: str) -> str:
     return yaml.dump(variables_obj)
 
 
+def data_source_keys_referenced_by(
+    expressions: List[str],
+) -> Optional[Collection[str]]:
+    """Return data_sources keys named by expressions, or None to load all keys."""
+    keys: set[str] = set()
+    for expr in expressions:
+        if not expr or not str(expr).strip():
+            continue
+        text = str(expr)
+        attrs = RE_DATA_SOURCE_ATTR.findall(text)
+        items = [m[1] for m in RE_DATA_SOURCE_ITEM.findall(text)]
+        keys.update(attrs)
+        keys.update(items)
+        if re.search(r"\bdata_sources\b", text) and not attrs and not items:
+            return None
+    return keys
+
+
 def prep_variables_for_template(
     *,
     variables: str,
     dependencies: Optional[Dict[str, Any]] = None,
     limit_query_results: Optional[int] = None,
     user: Optional["User"] = None,
+    data_source_keys: Optional[Collection[str]] = None,
+    include_charts: bool = True,
 ) -> Dict[str, Any]:
     if not dependencies:
         dependencies = {}
@@ -197,11 +239,14 @@ def prep_variables_for_template(
     # replace the data_sources with the actual data from DB. This will be passed to the template
     # in the form of {{data_sources.data_source_name}}
     variables_dict = process_data_sources(
-        variables=variables_dict, limit_query_results=limit_query_results, user=user
+        variables=variables_dict,
+        limit_query_results=limit_query_results,
+        user=user,
+        data_source_keys=data_source_keys,
     )
 
-    # generate and replace charts in the variables
-    variables_dict = process_chart_variables(variables=variables_dict)
+    if include_charts:
+        variables_dict = process_chart_variables(variables=variables_dict)
 
     return variables_dict
 
@@ -584,19 +629,23 @@ def process_data_sources(
     variables: Dict[str, Any],
     limit_query_results: Optional[int] = None,
     user: Optional["User"] = None,
+    data_source_keys: Optional[Collection[str]] = None,
 ) -> Dict[str, Any]:
     data_sources = variables.get("data_sources")
 
     if isinstance(data_sources, dict):
         for key, value in data_sources.items():
-            if isinstance(value, dict):
-                modified_datasource = resolve_model(data_source=value)
-                queryset = build_queryset(
-                    data_source=modified_datasource,
-                    limit=limit_query_results,
-                    user=user,
-                )
-                data_sources[key] = queryset
+            if data_source_keys is not None and key not in data_source_keys:
+                continue
+            if not isinstance(value, dict):
+                continue
+            modified_datasource = resolve_model(data_source=value)
+            queryset = build_queryset(
+                data_source=modified_datasource,
+                limit=limit_query_results,
+                user=user,
+            )
+            data_sources[key] = queryset
 
     return variables
 
@@ -740,6 +789,7 @@ def run_report(
     dependencies: Dict[str, int],
     format: Literal["html", "pdf", "plaintext"],
     user: Optional["User"] = None,
+    prepared_variables: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[str] | bytes, Optional[str], "ReportHistory"]:
     error_text = ""
     try:
@@ -753,6 +803,7 @@ def run_report(
             variables=template.template_variables,
             dependencies=dependencies,
             user=user,
+            prepared_variables=prepared_variables,
         )
 
         html_report = normalize_asset_url(html_report, format)
@@ -791,20 +842,109 @@ def build_report_link(id: int, format: str) -> str:
     return f"{settings.CORS_ORIGIN_WHITELIST[0]}/reports/history/{id}/?format={format}"
 
 
+def _update_schedule_last_run(
+    *,
+    schedule: "ReportSchedule",
+    status: str,
+    message: str = "",
+) -> None:
+    schedule.last_run = djangotime.now()
+    schedule.last_run_status = status
+    schedule.last_run_message = message[:500] if message else ""
+    schedule.save(
+        update_fields=["last_run", "last_run_status", "last_run_message"]
+    )
+
+
 def run_scheduled_report(
     *,
     schedule: "ReportSchedule",
     user: Optional["User"] = None,
-) -> Tuple["ReportHistory", Optional[str]]:
+) -> ScheduledReportRunResult:
+    template = schedule.report_template
+    prepared_variables: Optional[Dict[str, Any]] = None
+    conditions = list(schedule.conditions or [])
+
+    if conditions:
+        try:
+            keys = data_source_keys_referenced_by(conditions)
+            prepared_variables = prep_variables_for_template(
+                variables=template.template_variables,
+                dependencies=schedule.dependencies,
+                user=user,
+                data_source_keys=keys,
+                include_charts=False,
+            )
+            for index, expression in enumerate(conditions):
+                # compile_expression defaults to undefined_to_none=True, which
+                # turns a typo like `undefined_name` into None (falsy → skip).
+                value = condition_env.compile_expression(
+                    expression, undefined_to_none=False
+                )(**prepared_variables)
+                if isinstance(value, Undefined):
+                    raise UndefinedError(
+                        f"Condition {index + 1} used a name that does not exist: {expression}"
+                    )
+                if not value:
+                    message = f"Condition {index + 1} was not true"
+                    _update_schedule_last_run(
+                        schedule=schedule,
+                        status="skipped",
+                        message=message,
+                    )
+                    logger.info(
+                        "Report schedule %s skipped: %s",
+                        schedule.pk,
+                        message,
+                    )
+                    return ScheduledReportRunResult(
+                        status="skipped",
+                        skip_index=index,
+                        message=message,
+                    )
+
+            prepared_variables = process_data_sources(
+                variables=prepared_variables,
+                user=user,
+            )
+            prepared_variables = process_chart_variables(
+                variables=prepared_variables
+            )
+        except Exception as error:
+            error_text = str(error)
+            _update_schedule_last_run(
+                schedule=schedule,
+                status="error",
+                message=error_text,
+            )
+            logger.error(
+                "Report schedule %s condition error: %s",
+                schedule.pk,
+                error_text,
+            )
+            return ScheduledReportRunResult(status="error", error=error_text)
 
     report, error, history = run_report(
-        template=schedule.report_template,
+        template=template,
         dependencies=schedule.dependencies,
         format=schedule.format,
         user=user,
+        prepared_variables=prepared_variables,
     )
-    schedule.last_run = djangotime.now()
-    schedule.save(update_fields=["last_run"])
+
+    if error:
+        _update_schedule_last_run(
+            schedule=schedule,
+            status="error",
+            message=error,
+        )
+        return ScheduledReportRunResult(
+            status="error",
+            history=history,
+            error=error,
+        )
+
+    _update_schedule_last_run(schedule=schedule, status="success")
 
     if schedule.send_report_email:
         ee.reporting.tasks.email_report.delay(
@@ -820,7 +960,7 @@ def run_scheduled_report(
             include_report_link=schedule.email_settings.get("include_report_link"),
         )
 
-    return history, error
+    return ScheduledReportRunResult(status="success", history=history)
 
 
 # import report functions

--- a/api/tacticalrmm/ee/reporting/views.py
+++ b/api/tacticalrmm/ee/reporting/views.py
@@ -359,6 +359,12 @@ class ImportReportTemplate(APIView):
 class ReportScheduleSerializer(ModelSerializer):
     report_template_name = ReadOnlyField(source="report_template.name")
     schedule_name = ReadOnlyField(source="schedule.name")
+    conditions = ListField(
+        child=CharField(allow_blank=True),
+        required=False,
+        allow_empty=True,
+        default=list,
+    )
 
     class Meta:
         model = ReportSchedule
@@ -373,11 +379,44 @@ class ReportScheduleSerializer(ModelSerializer):
             "schedule_name",
             "email_recipients",
             "dependencies",
+            "conditions",
             "send_report_email",
             "last_run",
+            "last_run_status",
+            "last_run_message",
             "email_settings",
             "timezone",
         ]
+        read_only_fields = ["last_run", "last_run_status", "last_run_message"]
+
+    def validate_conditions(self, value):
+        from .utils import condition_env
+
+        if value is None:
+            return []
+
+        if not isinstance(value, list):
+            raise ValidationError("Conditions must be a list")
+
+        cleaned = []
+        for index, expression in enumerate(value):
+            if not isinstance(expression, str):
+                raise ValidationError(
+                    f"Condition {index + 1} must be text"
+                )
+            expr = expression.strip()
+            if expr.startswith("{{") and expr.endswith("}}"):
+                expr = expr[2:-2].strip()
+            if not expr:
+                continue
+            try:
+                condition_env.compile_expression(expr)
+            except Exception as error:
+                raise ValidationError(
+                    f"Condition {index + 1} is not valid: {error}"
+                ) from error
+            cleaned.append(expr)
+        return cleaned
 
 
 class GetAddReportSchedule(APIView):
@@ -430,13 +469,22 @@ class RunReportSchedule(APIView):
     def post(self, request: Request, pk: int) -> Response:
         schedule = get_object_or_404(ReportSchedule, pk=pk)
 
-        _, error = run_scheduled_report(schedule=schedule, user=request.user)
+        result = run_scheduled_report(schedule=schedule, user=request.user)
 
-        if error:
-            return notify_error(error)
+        if result.status == "error":
+            return notify_error(result.error or "Unknown error")
 
-        return Response()
+        if result.status == "skipped":
+            return Response(
+                {
+                    "status": "skipped",
+                    "reason": "condition",
+                    "index": result.skip_index,
+                    "message": result.message,
+                }
+            )
 
+        return Response({"status": "success"})
 
 class ReportHistorySerializer(ModelSerializer):
     report_template_name = ReadOnlyField(source="report_template.name")


### PR DESCRIPTION
We needed scheduled reports that stay quiet when there's nothing to send. A daily unhealthy agents mail that still goes out empty is the case that started this.

`ReportSchedule.conditions` is a list of Jinja expressions using the same variables as the template. Leave it empty and the schedule behaves as it does today. If any expression is not true, we skip the report and the email and set `last_run_status` to skipped.

A missing name or a broken expression is an error, not a skip. Jinja turns `undefined_name` into `None`, which is falsy, so that would have looked like "nothing to report." Manual `/run/` is 200 when skipped and 400 when it errors.

On skip we only query the `data_sources` the conditions name. No charts. On pass, each source is queried once, then charts, then render.

Migration `0005_reportschedule_conditions_and_last_run_status`. UI is a separate [PR on tacticalrmm-web](https://github.com/amidaware/tacticalrmm-web/pull/57).

## How I tested

- [x] `pytest ee/reporting/tests/test_schedule_conditions.py ee/reporting/tests/test_report_schedule_views.py`
- [x] Schedule with no conditions still runs and emails
- [x] `False` or empty `data_sources.foo|length > 0` skips. No history, no email, status skipped
- [x] `True` runs and emails. Each data source queried once
- [x] `undefined_name` is an error on manual run, not a skip
- [x] `{% for %}` is rejected on save
- [x] `migrate` applies 0005