### PR TITLE
Docker: don't enforce network address

### DIFF
--- a/docker/containers/tactical-meshcentral/entrypoint.sh
+++ b/docker/containers/tactical-meshcentral/entrypoint.sh
@@ -8,8 +8,8 @@ set -e
 : "${MONGODB_PASSWORD:=mongopass}"
 : "${MONGODB_HOST:=tactical-mongodb}"
 : "${MONGODB_PORT:=27017}"
-: "${NGINX_HOST_IP:=172.20.0.20}"
-: "${NGINX_HOST_PORT:=4443}"
+: "${NGINX_HOST:=tactical-nginx}"
+: "${NGINX_PORT:=4443}"
 : "${MESH_COMPRESSION_ENABLED:=false}"
 : "${MESH_PERSISTENT_CONFIG:=0}"
 : "${MESH_WEBRTC_ENABLED:=false}"
@@ -32,7 +32,7 @@ if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTE
   "settings": {
     "mongodb": "${encoded_uri}",
     "cert": "${MESH_HOST}",
-    "tlsOffload": "${NGINX_HOST_IP}",
+    "tlsOffload": "uniquelocal",
     "redirPort": 8080,
     "WANonly": true,
     "minify": 1,
@@ -62,7 +62,7 @@ if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTE
       "newAccounts": false,
       "mstsc": true,
       "geoLocation": true,
-      "certUrl": "https://${NGINX_HOST_IP}:${NGINX_HOST_PORT}",
+      "certUrl": "https://${NGINX_HOST}:${NGINX_PORT}",
       "agentConfig": [ "webSocketMaskOverride=${WS_MASK_OVERRIDE}" ]
     }
   },
@@ -95,7 +95,7 @@ if [ ! -f "${TACTICAL_DIR}/tmp/mesh_token" ]; then
 fi
 
 # wait for nginx container
-until (echo >/dev/tcp/"${NGINX_HOST_IP}"/${NGINX_HOST_PORT}) &>/dev/null; do
+until (echo >/dev/tcp/"${NGINX_HOST}"/${NGINX_PORT}) &>/dev/null; do
   echo "waiting for nginx to start..."
   sleep 5
 done

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,10 +4,6 @@ version: "3.7"
 networks:
   proxy:
     driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.20.0.0/24
   api-db: null
   redis: null
   mesh-db: null
@@ -195,8 +191,7 @@ services:
       CERT_PUB_KEY: ${CERT_PUB_KEY}
       CERT_PRIV_KEY: ${CERT_PRIV_KEY}
     networks:
-      proxy:
-        ipv4_address: 172.20.0.20
+      - proxy
     ports:
       - "${TRMM_HTTP_PORT-80}:8080"
       - "${TRMM_HTTPS_PORT-443}:4443"


### PR DESCRIPTION
Just started using the docker installation and found that enforcing the network address is inconvenient if there're more compose projects in the same server.

Using the nginx container name from meshcentral config is fine. Also changed `tlsOffload` to `uniquelocal`. See https://expressjs.com/en/5x/guide/behind-proxies/ for reference.